### PR TITLE
Tweak catalog generation

### DIFF
--- a/public/catalog/haddock3.easy.yaml
+++ b/public/catalog/haddock3.easy.yaml
@@ -1,15 +1,15 @@
 title: Haddock 3 on easy level
 categories:
-- name: refinement
-  description: HADDOCK3 actions referring to refinement.
-- name: sampling
-  description: HADDOCK3 modules for sampling.
-- name: analysis
-  description: HADDOCK3 modules related to model analysis.
-- name: scoring
-  description: HADDOCK3 modules to score modules.
 - name: topology
   description: HADDOCK3 modules to create topologies.
+- name: sampling
+  description: HADDOCK3 modules for sampling.
+- name: refinement
+  description: HADDOCK3 actions referring to refinement.
+- name: scoring
+  description: HADDOCK3 modules to score modules.
+- name: analysis
+  description: HADDOCK3 modules related to model analysis.
 global:
   schema:
     type: object
@@ -82,78 +82,1531 @@ global:
     cns_exec:
       ui:widget: file
 nodes:
-- id: clustfcc
-  category: analysis
-  label: HADDOCK3 FCC clustering module.
-  description: HADDOCK3 module for clustering with FCC.
+- id: topoaa
+  category: topology
+  label: Create and manage CNS all-atom topology.
+  description: HADDOCK3 module to create CNS all-atom topologies.
   schema:
     type: object
     properties:
-      executable:
-        default: src/contact_fcc
-        type: string
-        format: uri-reference
-      contact_distance_cutoff:
-        default: 5.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      fraction_cutoff:
-        default: 0.6
-        type: number
-        maximum: 9999
-        minimum: -9999
-      threshold:
-        default: 4
-        type: number
-        maximum: 9999
-        minimum: -9999
-      strictness:
-        default: 0.75
-        type: number
-        maximum: 9999
-        minimum: -9999
+      delenph:
+        default: true
+        title: Keep or remove non-polar hydrogen atoms
+        description: If set to true, non-polar hydrogen atoms will be discarded to
+          save computing time
+        $comment: Since HADDOCK uses a united atom force field, the non-polar hydrogen
+          atoms can be in principle discarded. This saves computing time. However
+          this should not be done if you are defining distance restraints to specific
+          hydrogen atoms (e.g. when using NMR distance restraints).
+        type: boolean
+      limit:
+        default: true
+        type: boolean
+      mol1:
+        type: object
+        properties:
+          prot_segid:
+            default: A
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol2:
+        type: object
+        properties:
+          prot_segid:
+            default: B
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol3:
+        type: object
+        properties:
+          prot_segid:
+            default: C
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol4:
+        type: object
+        properties:
+          prot_segid:
+            default: D
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol5:
+        type: object
+        properties:
+          prot_segid:
+            default: E
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol6:
+        type: object
+        properties:
+          prot_segid:
+            default: F
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol7:
+        type: object
+        properties:
+          prot_segid:
+            default: G
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol8:
+        type: object
+        properties:
+          prot_segid:
+            default: H
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol9:
+        type: object
+        properties:
+          prot_segid:
+            default: I
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol10:
+        type: object
+        properties:
+          prot_segid:
+            default: J
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol11:
+        type: object
+        properties:
+          prot_segid:
+            default: K
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol12:
+        type: object
+        properties:
+          prot_segid:
+            default: L
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol13:
+        type: object
+        properties:
+          prot_segid:
+            default: M
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol14:
+        type: object
+        properties:
+          prot_segid:
+            default: N
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol15:
+        type: object
+        properties:
+          prot_segid:
+            default: O
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol16:
+        type: object
+        properties:
+          prot_segid:
+            default: P
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol17:
+        type: object
+        properties:
+          prot_segid:
+            default: Q
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol18:
+        type: object
+        properties:
+          prot_segid:
+            default: R
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol19:
+        type: object
+        properties:
+          prot_segid:
+            default: S
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol20:
+        type: object
+        properties:
+          prot_segid:
+            default: T
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
     required: []
     additionalProperties: false
   uiSchema:
-    executable:
-      ui:widget: file
-- id: seletop
-  category: analysis
-  label: HADDOCK3 module to select a top cluster/model.
-  description: HADDOCK3 module to select top cluster/model.
-  schema:
-    type: object
-    properties:
-      select:
-        default: 200
-        type: number
-        maximum: 9999
-        minimum: -9999
-    required: []
-    additionalProperties: false
-  uiSchema: {}
-- id: seletopclusts
-  category: analysis
-  label: HADDOCK3 module to select a top cluster/model.
-  description: Haddock Module for 'seletopclusts'.
-  schema:
-    type: object
-    properties:
-      top_cluster:
-        default: []
-        type: array
-        minItems: 0
-        maxItems: 100
-        items:
-          type: number
-      top_models:
-        type: number
-        maximum: 9999
-        minimum: -9999
-    required: []
-    additionalProperties: false
-  uiSchema: {}
+    delenph:
+      ui:group: molecule
+    mol1:
+      mol1:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol2:
+      mol2:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol3:
+      mol3:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol4:
+      mol4:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol5:
+      mol5:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol6:
+      mol6:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol7:
+      mol7:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol8:
+      mol8:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol9:
+      mol9:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol10:
+      mol10:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol11:
+      mol11:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol12:
+      mol12:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol13:
+      mol13:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol14:
+      mol14:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol15:
+      mol15:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol16:
+      mol16:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol17:
+      mol17:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol18:
+      mol18:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol19:
+      mol19:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol20:
+      mol20:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
 - id: caprieval
   category: analysis
   label: Calculate CAPRI metrics.
@@ -235,6 +1688,152 @@ nodes:
   uiSchema:
     reference_fname:
       ui:widget: file
+- id: seletop
+  category: analysis
+  label: HADDOCK3 module to select a top cluster/model.
+  description: HADDOCK3 module to select top cluster/model.
+  schema:
+    type: object
+    properties:
+      select:
+        default: 200
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema: {}
+- id: clustfcc
+  category: analysis
+  label: HADDOCK3 FCC clustering module.
+  description: HADDOCK3 module for clustering with FCC.
+  schema:
+    type: object
+    properties:
+      executable:
+        default: src/contact_fcc
+        type: string
+        format: uri-reference
+      contact_distance_cutoff:
+        default: 5.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      fraction_cutoff:
+        default: 0.6
+        type: number
+        maximum: 9999
+        minimum: -9999
+      threshold:
+        default: 4
+        type: number
+        maximum: 9999
+        minimum: -9999
+      strictness:
+        default: 0.75
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema:
+    executable:
+      ui:widget: file
+- id: seletopclusts
+  category: analysis
+  label: HADDOCK3 module to select a top cluster/model.
+  description: Haddock Module for 'seletopclusts'.
+  schema:
+    type: object
+    properties:
+      top_cluster:
+        default: []
+        type: array
+        minItems: 0
+        maxItems: 100
+        items:
+          type: number
+      top_models:
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema: {}
+- id: lightdock
+  category: sampling
+  label: Run Lightdock as a HADDOCK3 module.
+  description: HADDOCK3 Lightdock module.
+  schema:
+    type: object
+    properties:
+      glowworms:
+        default: 200
+        type: number
+        maximum: 9999
+        minimum: -9999
+      steps:
+        default: 100
+        type: number
+        maximum: 9999
+        minimum: -9999
+      swarms:
+        default: 400
+        type: number
+        maximum: 9999
+        minimum: -9999
+      scoring:
+        default: fastdfire
+        type: string
+        minLength: 0
+        maxLength: 100
+      top:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      receptor_chains:
+        default: A
+        type: string
+        minLength: 0
+        maxLength: 100
+      receptor_active:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      receptor_passive:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_chains:
+        default: B
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_active:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_passive:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      noxt:
+        default: true
+        type: boolean
+      noh:
+        default: true
+        type: boolean
+      restraints:
+        default: false
+        type: boolean
+    required: []
+    additionalProperties: false
+  uiSchema: {}
 - id: gdock
   category: sampling
   label: HADDOCK3 gdock integration module.
@@ -2509,1199 +4108,10 @@ nodes:
       ui:widget: file
     ligand_top_fname:
       ui:widget: file
-- id: lightdock
-  category: sampling
-  label: Run Lightdock as a HADDOCK3 module.
-  description: HADDOCK3 Lightdock module.
-  schema:
-    type: object
-    properties:
-      glowworms:
-        default: 200
-        type: number
-        maximum: 9999
-        minimum: -9999
-      steps:
-        default: 100
-        type: number
-        maximum: 9999
-        minimum: -9999
-      swarms:
-        default: 400
-        type: number
-        maximum: 9999
-        minimum: -9999
-      scoring:
-        default: fastdfire
-        type: string
-        minLength: 0
-        maxLength: 100
-      top:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      receptor_chains:
-        default: A
-        type: string
-        minLength: 0
-        maxLength: 100
-      receptor_active:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      receptor_passive:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_chains:
-        default: B
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_active:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_passive:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      noxt:
-        default: true
-        type: boolean
-      noh:
-        default: true
-        type: boolean
-      restraints:
-        default: false
-        type: boolean
-    required: []
-    additionalProperties: false
-  uiSchema: {}
-- id: topoaa
-  category: topology
-  label: Create and manage CNS all-atom topology.
-  description: HADDOCK3 module to create CNS all-atom topologies.
-  schema:
-    type: object
-    properties:
-      autohis:
-        default: true
-        title: Automatic HIS protonation state
-        description: 'The protonation state of histidine (+1: HIS or 0: HISD/HISE)
-          will be automatically set by HADDOCK'
-        $comment: 'If set to true, HADDOCK will automatically define the protonation
-          state of histidines ((+1: HIS or 0: HISD/HISE) by selecting the state leading
-          to the lowest electrostatic energy'
-        type: boolean
-      delenph:
-        default: true
-        title: Keep or remove non-polar hydrogen atoms
-        description: If set to true, non-polar hydrogen atoms will be discarded to
-          save computing time
-        $comment: Since HADDOCK uses a united atom force field, the non-polar hydrogen
-          atoms can be in principle discarded. This saves computing time. However
-          this should not be done if you are defining distance restraints to specific
-          hydrogen atoms (e.g. when using NMR distance restraints).
-        type: boolean
-      ligand_param_fname:
-        type: string
-        format: uri-reference
-      ligand_top_fname:
-        type: string
-        format: uri-reference
-      limit:
-        default: true
-        type: boolean
-      tolerance:
-        default: 0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mol1:
-        type: object
-        properties:
-          prot_segid:
-            default: A
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol2:
-        type: object
-        properties:
-          prot_segid:
-            default: B
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol3:
-        type: object
-        properties:
-          prot_segid:
-            default: C
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol4:
-        type: object
-        properties:
-          prot_segid:
-            default: D
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol5:
-        type: object
-        properties:
-          prot_segid:
-            default: E
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol6:
-        type: object
-        properties:
-          prot_segid:
-            default: F
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol7:
-        type: object
-        properties:
-          prot_segid:
-            default: G
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol8:
-        type: object
-        properties:
-          prot_segid:
-            default: H
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol9:
-        type: object
-        properties:
-          prot_segid:
-            default: I
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol10:
-        type: object
-        properties:
-          prot_segid:
-            default: J
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol11:
-        type: object
-        properties:
-          prot_segid:
-            default: K
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol12:
-        type: object
-        properties:
-          prot_segid:
-            default: L
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol13:
-        type: object
-        properties:
-          prot_segid:
-            default: M
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol14:
-        type: object
-        properties:
-          prot_segid:
-            default: N
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol15:
-        type: object
-        properties:
-          prot_segid:
-            default: O
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol16:
-        type: object
-        properties:
-          prot_segid:
-            default: P
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol17:
-        type: object
-        properties:
-          prot_segid:
-            default: Q
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol18:
-        type: object
-        properties:
-          prot_segid:
-            default: R
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol19:
-        type: object
-        properties:
-          prot_segid:
-            default: S
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol20:
-        type: object
-        properties:
-          prot_segid:
-            default: T
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-    required: []
-    additionalProperties: false
-  uiSchema:
-    autohis:
-      ui:group: molecule
-    delenph:
-      ui:group: molecule
-    ligand_param_fname:
-      ui:widget: file
-    ligand_top_fname:
-      ui:widget: file
-- id: emscoring
-  category: scoring
-  label: HADDOCK3 scoring module.
-  description: HADDOCK3 module to perform energy minimization scoring.
-  schema:
-    type: object
-    properties:
-      tolerance:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      log_level:
-        default: verbose
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_param_fname:
-        type: string
-        format: uri-reference
-      ligand_top_fname:
-        type: string
-        format: uri-reference
-      individualize:
-        default: true
-        type: boolean
-      nemsteps:
-        default: 40
-        type: number
-        maximum: 9999
-        minimum: -9999
-      elecflag:
-        default: true
-        type: boolean
-      dielec:
-        default: cdie
-        type: string
-        minLength: 0
-        maxLength: 100
-      epsilon:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedflag:
-        default: true
-        type: boolean
-      par_nonbonded:
-        default: OPLSX
-        type: string
-        minLength: 0
-        maxLength: 100
-      w_air:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_bsa:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_cdih:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_dani:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_deint:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_desolv:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_dist:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_elec:
-        default: 0.2
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_lcc:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_rg:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_sani:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_sym:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_vdw:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_vean:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_xpcs:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_xrdc:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_zres:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      shape_1:
-        default: false
-        type: boolean
-      shape_2:
-        default: false
-        type: boolean
-      shape_3:
-        default: false
-        type: boolean
-      shape_4:
-        default: false
-        type: boolean
-      shape_5:
-        default: false
-        type: boolean
-      shape_6:
-        default: false
-        type: boolean
-      shape_7:
-        default: false
-        type: boolean
-      shape_8:
-        default: false
-        type: boolean
-      shape_9:
-        default: false
-        type: boolean
-      shape_10:
-        default: false
-        type: boolean
-      shape_11:
-        default: false
-        type: boolean
-      shape_12:
-        default: false
-        type: boolean
-      shape_13:
-        default: false
-        type: boolean
-      shape_14:
-        default: false
-        type: boolean
-      shape_15:
-        default: false
-        type: boolean
-      shape_16:
-        default: false
-        type: boolean
-      shape_17:
-        default: false
-        type: boolean
-      shape_18:
-        default: false
-        type: boolean
-      shape_19:
-        default: false
-        type: boolean
-      shape_20:
-        default: false
-        type: boolean
-    required: []
-    additionalProperties: false
-  uiSchema:
-    ligand_param_fname:
-      ui:widget: file
-    ligand_top_fname:
-      ui:widget: file
-- id: flexref
+- id: emref
   category: refinement
-  label: HADDOCK3 module for flexible refinement.
-  description: HADDOCK3 module for flexible refinement.
+  label: HADDOCK3 module for energy minimization refinement.
+  description: HADDOCK3 module energy minimization refinement.
   schema:
     type: object
     properties:
@@ -3733,8 +4143,18 @@ nodes:
       ligand_top_fname:
         type: string
         format: uri-reference
+      sampling:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
       sampling_factor:
         default: 1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      nemsteps:
+        default: 200
         type: number
         maximum: 9999
         minimum: -9999
@@ -3746,101 +4166,6 @@ nodes:
       keepwater:
         default: false
         type: boolean
-      mdsteps_rigid:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool1:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool2:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool3:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      timestep:
-        default: 0.002
-        type: number
-        maximum: 9999
-        minimum: -9999
-      tadfactor:
-        default: 8
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_rigid_init:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_rigid_final:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool2_init:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool2_final:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool3_init:
-        default: 0.05
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool3_final:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_high:
-        default: 2000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool1_init:
-        default: 2000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool1_final:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool2_init:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool2_final:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool3_init:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool3_final:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
       prot_segid_1:
         default: A
         type: string
@@ -4001,62 +4326,17 @@ nodes:
       shape_20:
         default: false
         type: boolean
-      amb_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      amb_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      amb_cool2:
+      amb_scale:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      amb_cool3:
+      unamb_scale:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      unamb_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool3:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool3:
+      hbond_scale:
         default: 50
         type: number
         maximum: 9999
@@ -4069,86 +4349,6 @@ nodes:
         type: boolean
       ncvpart:
         default: 2
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_hot:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool1:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool2:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool3:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_hot:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool1:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool2:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool3:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_hot:
-        default: -1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool1:
-        default: -1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool2:
-        default: -0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool3:
-        default: -0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_hot:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool1:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool2:
-        default: 0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool3:
-        default: 0.1
         type: number
         maximum: 9999
         minimum: -9999
@@ -4177,22 +4377,7 @@ nodes:
       dihedrals_on:
         default: false
         type: boolean
-      dihedrals_hot:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool1:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool3:
+      dihedrals_scale:
         default: 200
         type: number
         maximum: 9999
@@ -5172,7 +5357,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_bsa:
-        default: -0.01
+        default: 0.0
         type: number
         maximum: 9999
         minimum: -9999
@@ -5202,7 +5387,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_elec:
-        default: 1.0
+        default: 0.2
         type: number
         maximum: 9999
         minimum: -9999
@@ -5255,7 +5440,7 @@ nodes:
         default: true
         type: boolean
       dielec:
-        default: rdie
+        default: cdie
         type: string
         minLength: 0
         maxLength: 100
@@ -8766,10 +8951,10 @@ nodes:
       ui:widget: file
     ligand_top_fname:
       ui:widget: file
-- id: emref
+- id: flexref
   category: refinement
-  label: HADDOCK3 module for energy minimization refinement.
-  description: HADDOCK3 module energy minimization refinement.
+  label: HADDOCK3 module for flexible refinement.
+  description: HADDOCK3 module for flexible refinement.
   schema:
     type: object
     properties:
@@ -8801,18 +8986,8 @@ nodes:
       ligand_top_fname:
         type: string
         format: uri-reference
-      sampling:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
       sampling_factor:
         default: 1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      nemsteps:
-        default: 200
         type: number
         maximum: 9999
         minimum: -9999
@@ -8824,6 +8999,101 @@ nodes:
       keepwater:
         default: false
         type: boolean
+      mdsteps_rigid:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool1:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool2:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool3:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      timestep:
+        default: 0.002
+        type: number
+        maximum: 9999
+        minimum: -9999
+      tadfactor:
+        default: 8
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_rigid_init:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_rigid_final:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool2_init:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool2_final:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool3_init:
+        default: 0.05
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool3_final:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_high:
+        default: 2000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool1_init:
+        default: 2000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool1_final:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool2_init:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool2_final:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool3_init:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool3_final:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
       prot_segid_1:
         default: A
         type: string
@@ -8984,17 +9254,62 @@ nodes:
       shape_20:
         default: false
         type: boolean
-      amb_scale:
+      amb_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      amb_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      amb_cool2:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      unamb_scale:
+      amb_cool3:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      hbond_scale:
+      unamb_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool3:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool3:
         default: 50
         type: number
         maximum: 9999
@@ -9007,6 +9322,86 @@ nodes:
         type: boolean
       ncvpart:
         default: 2
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_hot:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool1:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool2:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool3:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_hot:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool1:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool2:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool3:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_hot:
+        default: -1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool1:
+        default: -1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool2:
+        default: -0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool3:
+        default: -0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_hot:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool1:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool2:
+        default: 0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool3:
+        default: 0.1
         type: number
         maximum: 9999
         minimum: -9999
@@ -9035,7 +9430,22 @@ nodes:
       dihedrals_on:
         default: false
         type: boolean
-      dihedrals_scale:
+      dihedrals_hot:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool1:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool3:
         default: 200
         type: number
         maximum: 9999
@@ -10015,7 +10425,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_bsa:
-        default: 0.0
+        default: -0.01
         type: number
         maximum: 9999
         minimum: -9999
@@ -10045,7 +10455,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_elec:
-        default: 0.2
+        default: 1.0
         type: number
         maximum: 9999
         minimum: -9999
@@ -10098,7 +10508,7 @@ nodes:
         default: true
         type: boolean
       dielec:
-        default: cdie
+        default: rdie
         type: string
         minLength: 0
         maxLength: 100
@@ -11176,6 +11586,210 @@ nodes:
       ui:widget: file
     hbond_fname:
       ui:widget: file
+    ligand_param_fname:
+      ui:widget: file
+    ligand_top_fname:
+      ui:widget: file
+- id: emscoring
+  category: scoring
+  label: HADDOCK3 scoring module.
+  description: HADDOCK3 module to perform energy minimization scoring.
+  schema:
+    type: object
+    properties:
+      tolerance:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      log_level:
+        default: verbose
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_param_fname:
+        type: string
+        format: uri-reference
+      ligand_top_fname:
+        type: string
+        format: uri-reference
+      individualize:
+        default: true
+        type: boolean
+      nemsteps:
+        default: 40
+        type: number
+        maximum: 9999
+        minimum: -9999
+      elecflag:
+        default: true
+        type: boolean
+      dielec:
+        default: cdie
+        type: string
+        minLength: 0
+        maxLength: 100
+      epsilon:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedflag:
+        default: true
+        type: boolean
+      par_nonbonded:
+        default: OPLSX
+        type: string
+        minLength: 0
+        maxLength: 100
+      w_air:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_bsa:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_cdih:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_dani:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_deint:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_desolv:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_dist:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_elec:
+        default: 0.2
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_lcc:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_rg:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_sani:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_sym:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_vdw:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_vean:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_xpcs:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_xrdc:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_zres:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      shape_1:
+        default: false
+        type: boolean
+      shape_2:
+        default: false
+        type: boolean
+      shape_3:
+        default: false
+        type: boolean
+      shape_4:
+        default: false
+        type: boolean
+      shape_5:
+        default: false
+        type: boolean
+      shape_6:
+        default: false
+        type: boolean
+      shape_7:
+        default: false
+        type: boolean
+      shape_8:
+        default: false
+        type: boolean
+      shape_9:
+        default: false
+        type: boolean
+      shape_10:
+        default: false
+        type: boolean
+      shape_11:
+        default: false
+        type: boolean
+      shape_12:
+        default: false
+        type: boolean
+      shape_13:
+        default: false
+        type: boolean
+      shape_14:
+        default: false
+        type: boolean
+      shape_15:
+        default: false
+        type: boolean
+      shape_16:
+        default: false
+        type: boolean
+      shape_17:
+        default: false
+        type: boolean
+      shape_18:
+        default: false
+        type: boolean
+      shape_19:
+        default: false
+        type: boolean
+      shape_20:
+        default: false
+        type: boolean
+    required: []
+    additionalProperties: false
+  uiSchema:
     ligand_param_fname:
       ui:widget: file
     ligand_top_fname:

--- a/public/catalog/haddock3.expert.yaml
+++ b/public/catalog/haddock3.expert.yaml
@@ -1,15 +1,15 @@
 title: Haddock 3 on expert level
 categories:
-- name: refinement
-  description: HADDOCK3 actions referring to refinement.
-- name: sampling
-  description: HADDOCK3 modules for sampling.
-- name: analysis
-  description: HADDOCK3 modules related to model analysis.
-- name: scoring
-  description: HADDOCK3 modules to score modules.
 - name: topology
   description: HADDOCK3 modules to create topologies.
+- name: sampling
+  description: HADDOCK3 modules for sampling.
+- name: refinement
+  description: HADDOCK3 actions referring to refinement.
+- name: scoring
+  description: HADDOCK3 modules to score modules.
+- name: analysis
+  description: HADDOCK3 modules related to model analysis.
 global:
   schema:
     type: object
@@ -82,78 +82,1563 @@ global:
     cns_exec:
       ui:widget: file
 nodes:
-- id: clustfcc
-  category: analysis
-  label: HADDOCK3 FCC clustering module.
-  description: HADDOCK3 module for clustering with FCC.
+- id: topoaa
+  category: topology
+  label: Create and manage CNS all-atom topology.
+  description: HADDOCK3 module to create CNS all-atom topologies.
   schema:
     type: object
     properties:
-      executable:
-        default: src/contact_fcc
+      autohis:
+        default: true
+        title: Automatic HIS protonation state
+        description: 'The protonation state of histidine (+1: HIS or 0: HISD/HISE)
+          will be automatically set by HADDOCK'
+        $comment: 'If set to true, HADDOCK will automatically define the protonation
+          state of histidines ((+1: HIS or 0: HISD/HISE) by selecting the state leading
+          to the lowest electrostatic energy'
+        type: boolean
+      delenph:
+        default: true
+        title: Keep or remove non-polar hydrogen atoms
+        description: If set to true, non-polar hydrogen atoms will be discarded to
+          save computing time
+        $comment: Since HADDOCK uses a united atom force field, the non-polar hydrogen
+          atoms can be in principle discarded. This saves computing time. However
+          this should not be done if you are defining distance restraints to specific
+          hydrogen atoms (e.g. when using NMR distance restraints).
+        type: boolean
+      ligand_top_fname:
+        title: Custom ligand topology file
+        description: Ligand topology file in CNS format
+        $comment: Ligand topology file in CNS format containing the ligand topologies
+          (atoms, masses, charges, bond definitions...) for any ligand not supported
+          by default by HADDOCK
         type: string
         format: uri-reference
-      contact_distance_cutoff:
-        default: 5.0
+      limit:
+        default: true
+        type: boolean
+      tolerance:
+        default: 0
+        title: Failure tolerance percentage
+        description: Percentage of allowed failures for a module to successfully complete
+        $comment: Percentage of allowed failures for a module to successfully complete
         type: number
-        maximum: 9999
-        minimum: -9999
-      fraction_cutoff:
-        default: 0.6
-        type: number
-        maximum: 9999
-        minimum: -9999
-      threshold:
-        default: 4
-        type: number
-        maximum: 9999
-        minimum: -9999
-      strictness:
-        default: 0.75
-        type: number
-        maximum: 9999
-        minimum: -9999
+        maximum: 99
+        minimum: 0
+      mol1:
+        type: object
+        properties:
+          prot_segid:
+            default: A
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol2:
+        type: object
+        properties:
+          prot_segid:
+            default: B
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol3:
+        type: object
+        properties:
+          prot_segid:
+            default: C
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol4:
+        type: object
+        properties:
+          prot_segid:
+            default: D
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol5:
+        type: object
+        properties:
+          prot_segid:
+            default: E
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol6:
+        type: object
+        properties:
+          prot_segid:
+            default: F
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol7:
+        type: object
+        properties:
+          prot_segid:
+            default: G
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol8:
+        type: object
+        properties:
+          prot_segid:
+            default: H
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol9:
+        type: object
+        properties:
+          prot_segid:
+            default: I
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol10:
+        type: object
+        properties:
+          prot_segid:
+            default: J
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol11:
+        type: object
+        properties:
+          prot_segid:
+            default: K
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol12:
+        type: object
+        properties:
+          prot_segid:
+            default: L
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol13:
+        type: object
+        properties:
+          prot_segid:
+            default: M
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol14:
+        type: object
+        properties:
+          prot_segid:
+            default: N
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol15:
+        type: object
+        properties:
+          prot_segid:
+            default: O
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol16:
+        type: object
+        properties:
+          prot_segid:
+            default: P
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol17:
+        type: object
+        properties:
+          prot_segid:
+            default: Q
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol18:
+        type: object
+        properties:
+          prot_segid:
+            default: R
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol19:
+        type: object
+        properties:
+          prot_segid:
+            default: S
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol20:
+        type: object
+        properties:
+          prot_segid:
+            default: T
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
     required: []
     additionalProperties: false
   uiSchema:
-    executable:
+    autohis:
+      ui:group: molecule
+    delenph:
+      ui:group: molecule
+    ligand_top_fname:
       ui:widget: file
-- id: seletop
-  category: analysis
-  label: HADDOCK3 module to select a top cluster/model.
-  description: HADDOCK3 module to select top cluster/model.
-  schema:
-    type: object
-    properties:
-      select:
-        default: 200
-        type: number
-        maximum: 9999
-        minimum: -9999
-    required: []
-    additionalProperties: false
-  uiSchema: {}
-- id: seletopclusts
-  category: analysis
-  label: HADDOCK3 module to select a top cluster/model.
-  description: Haddock Module for 'seletopclusts'.
-  schema:
-    type: object
-    properties:
-      top_cluster:
-        default: []
-        type: array
-        minItems: 0
-        maxItems: 100
-        items:
-          type: number
-      top_models:
-        type: number
-        maximum: 9999
-        minimum: -9999
-    required: []
-    additionalProperties: false
-  uiSchema: {}
+      ui:group: force field
+    tolerance:
+      ui:group: module
+    mol1:
+      mol1:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol2:
+      mol2:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol3:
+      mol3:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol4:
+      mol4:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol5:
+      mol5:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol6:
+      mol6:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol7:
+      mol7:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol8:
+      mol8:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol9:
+      mol9:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol10:
+      mol10:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol11:
+      mol11:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol12:
+      mol12:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol13:
+      mol13:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol14:
+      mol14:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol15:
+      mol15:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol16:
+      mol16:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol17:
+      mol17:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol18:
+      mol18:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol19:
+      mol19:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol20:
+      mol20:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
 - id: caprieval
   category: analysis
   label: Calculate CAPRI metrics.
@@ -235,6 +1720,152 @@ nodes:
   uiSchema:
     reference_fname:
       ui:widget: file
+- id: seletop
+  category: analysis
+  label: HADDOCK3 module to select a top cluster/model.
+  description: HADDOCK3 module to select top cluster/model.
+  schema:
+    type: object
+    properties:
+      select:
+        default: 200
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema: {}
+- id: clustfcc
+  category: analysis
+  label: HADDOCK3 FCC clustering module.
+  description: HADDOCK3 module for clustering with FCC.
+  schema:
+    type: object
+    properties:
+      executable:
+        default: src/contact_fcc
+        type: string
+        format: uri-reference
+      contact_distance_cutoff:
+        default: 5.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      fraction_cutoff:
+        default: 0.6
+        type: number
+        maximum: 9999
+        minimum: -9999
+      threshold:
+        default: 4
+        type: number
+        maximum: 9999
+        minimum: -9999
+      strictness:
+        default: 0.75
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema:
+    executable:
+      ui:widget: file
+- id: seletopclusts
+  category: analysis
+  label: HADDOCK3 module to select a top cluster/model.
+  description: Haddock Module for 'seletopclusts'.
+  schema:
+    type: object
+    properties:
+      top_cluster:
+        default: []
+        type: array
+        minItems: 0
+        maxItems: 100
+        items:
+          type: number
+      top_models:
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema: {}
+- id: lightdock
+  category: sampling
+  label: Run Lightdock as a HADDOCK3 module.
+  description: HADDOCK3 Lightdock module.
+  schema:
+    type: object
+    properties:
+      glowworms:
+        default: 200
+        type: number
+        maximum: 9999
+        minimum: -9999
+      steps:
+        default: 100
+        type: number
+        maximum: 9999
+        minimum: -9999
+      swarms:
+        default: 400
+        type: number
+        maximum: 9999
+        minimum: -9999
+      scoring:
+        default: fastdfire
+        type: string
+        minLength: 0
+        maxLength: 100
+      top:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      receptor_chains:
+        default: A
+        type: string
+        minLength: 0
+        maxLength: 100
+      receptor_active:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      receptor_passive:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_chains:
+        default: B
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_active:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_passive:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      noxt:
+        default: true
+        type: boolean
+      noh:
+        default: true
+        type: boolean
+      restraints:
+        default: false
+        type: boolean
+    required: []
+    additionalProperties: false
+  uiSchema: {}
 - id: gdock
   category: sampling
   label: HADDOCK3 gdock integration module.
@@ -2509,1199 +4140,10 @@ nodes:
       ui:widget: file
     ligand_top_fname:
       ui:widget: file
-- id: lightdock
-  category: sampling
-  label: Run Lightdock as a HADDOCK3 module.
-  description: HADDOCK3 Lightdock module.
-  schema:
-    type: object
-    properties:
-      glowworms:
-        default: 200
-        type: number
-        maximum: 9999
-        minimum: -9999
-      steps:
-        default: 100
-        type: number
-        maximum: 9999
-        minimum: -9999
-      swarms:
-        default: 400
-        type: number
-        maximum: 9999
-        minimum: -9999
-      scoring:
-        default: fastdfire
-        type: string
-        minLength: 0
-        maxLength: 100
-      top:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      receptor_chains:
-        default: A
-        type: string
-        minLength: 0
-        maxLength: 100
-      receptor_active:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      receptor_passive:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_chains:
-        default: B
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_active:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_passive:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      noxt:
-        default: true
-        type: boolean
-      noh:
-        default: true
-        type: boolean
-      restraints:
-        default: false
-        type: boolean
-    required: []
-    additionalProperties: false
-  uiSchema: {}
-- id: topoaa
-  category: topology
-  label: Create and manage CNS all-atom topology.
-  description: HADDOCK3 module to create CNS all-atom topologies.
-  schema:
-    type: object
-    properties:
-      autohis:
-        default: true
-        title: Automatic HIS protonation state
-        description: 'The protonation state of histidine (+1: HIS or 0: HISD/HISE)
-          will be automatically set by HADDOCK'
-        $comment: 'If set to true, HADDOCK will automatically define the protonation
-          state of histidines ((+1: HIS or 0: HISD/HISE) by selecting the state leading
-          to the lowest electrostatic energy'
-        type: boolean
-      delenph:
-        default: true
-        title: Keep or remove non-polar hydrogen atoms
-        description: If set to true, non-polar hydrogen atoms will be discarded to
-          save computing time
-        $comment: Since HADDOCK uses a united atom force field, the non-polar hydrogen
-          atoms can be in principle discarded. This saves computing time. However
-          this should not be done if you are defining distance restraints to specific
-          hydrogen atoms (e.g. when using NMR distance restraints).
-        type: boolean
-      ligand_param_fname:
-        type: string
-        format: uri-reference
-      ligand_top_fname:
-        type: string
-        format: uri-reference
-      limit:
-        default: true
-        type: boolean
-      tolerance:
-        default: 0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mol1:
-        type: object
-        properties:
-          prot_segid:
-            default: A
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol2:
-        type: object
-        properties:
-          prot_segid:
-            default: B
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol3:
-        type: object
-        properties:
-          prot_segid:
-            default: C
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol4:
-        type: object
-        properties:
-          prot_segid:
-            default: D
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol5:
-        type: object
-        properties:
-          prot_segid:
-            default: E
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol6:
-        type: object
-        properties:
-          prot_segid:
-            default: F
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol7:
-        type: object
-        properties:
-          prot_segid:
-            default: G
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol8:
-        type: object
-        properties:
-          prot_segid:
-            default: H
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol9:
-        type: object
-        properties:
-          prot_segid:
-            default: I
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol10:
-        type: object
-        properties:
-          prot_segid:
-            default: J
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol11:
-        type: object
-        properties:
-          prot_segid:
-            default: K
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol12:
-        type: object
-        properties:
-          prot_segid:
-            default: L
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol13:
-        type: object
-        properties:
-          prot_segid:
-            default: M
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol14:
-        type: object
-        properties:
-          prot_segid:
-            default: N
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol15:
-        type: object
-        properties:
-          prot_segid:
-            default: O
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol16:
-        type: object
-        properties:
-          prot_segid:
-            default: P
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol17:
-        type: object
-        properties:
-          prot_segid:
-            default: Q
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol18:
-        type: object
-        properties:
-          prot_segid:
-            default: R
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol19:
-        type: object
-        properties:
-          prot_segid:
-            default: S
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol20:
-        type: object
-        properties:
-          prot_segid:
-            default: T
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-    required: []
-    additionalProperties: false
-  uiSchema:
-    autohis:
-      ui:group: molecule
-    delenph:
-      ui:group: molecule
-    ligand_param_fname:
-      ui:widget: file
-    ligand_top_fname:
-      ui:widget: file
-- id: emscoring
-  category: scoring
-  label: HADDOCK3 scoring module.
-  description: HADDOCK3 module to perform energy minimization scoring.
-  schema:
-    type: object
-    properties:
-      tolerance:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      log_level:
-        default: verbose
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_param_fname:
-        type: string
-        format: uri-reference
-      ligand_top_fname:
-        type: string
-        format: uri-reference
-      individualize:
-        default: true
-        type: boolean
-      nemsteps:
-        default: 40
-        type: number
-        maximum: 9999
-        minimum: -9999
-      elecflag:
-        default: true
-        type: boolean
-      dielec:
-        default: cdie
-        type: string
-        minLength: 0
-        maxLength: 100
-      epsilon:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedflag:
-        default: true
-        type: boolean
-      par_nonbonded:
-        default: OPLSX
-        type: string
-        minLength: 0
-        maxLength: 100
-      w_air:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_bsa:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_cdih:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_dani:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_deint:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_desolv:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_dist:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_elec:
-        default: 0.2
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_lcc:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_rg:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_sani:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_sym:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_vdw:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_vean:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_xpcs:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_xrdc:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_zres:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      shape_1:
-        default: false
-        type: boolean
-      shape_2:
-        default: false
-        type: boolean
-      shape_3:
-        default: false
-        type: boolean
-      shape_4:
-        default: false
-        type: boolean
-      shape_5:
-        default: false
-        type: boolean
-      shape_6:
-        default: false
-        type: boolean
-      shape_7:
-        default: false
-        type: boolean
-      shape_8:
-        default: false
-        type: boolean
-      shape_9:
-        default: false
-        type: boolean
-      shape_10:
-        default: false
-        type: boolean
-      shape_11:
-        default: false
-        type: boolean
-      shape_12:
-        default: false
-        type: boolean
-      shape_13:
-        default: false
-        type: boolean
-      shape_14:
-        default: false
-        type: boolean
-      shape_15:
-        default: false
-        type: boolean
-      shape_16:
-        default: false
-        type: boolean
-      shape_17:
-        default: false
-        type: boolean
-      shape_18:
-        default: false
-        type: boolean
-      shape_19:
-        default: false
-        type: boolean
-      shape_20:
-        default: false
-        type: boolean
-    required: []
-    additionalProperties: false
-  uiSchema:
-    ligand_param_fname:
-      ui:widget: file
-    ligand_top_fname:
-      ui:widget: file
-- id: flexref
+- id: emref
   category: refinement
-  label: HADDOCK3 module for flexible refinement.
-  description: HADDOCK3 module for flexible refinement.
+  label: HADDOCK3 module for energy minimization refinement.
+  description: HADDOCK3 module energy minimization refinement.
   schema:
     type: object
     properties:
@@ -3733,8 +4175,18 @@ nodes:
       ligand_top_fname:
         type: string
         format: uri-reference
+      sampling:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
       sampling_factor:
         default: 1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      nemsteps:
+        default: 200
         type: number
         maximum: 9999
         minimum: -9999
@@ -3746,101 +4198,6 @@ nodes:
       keepwater:
         default: false
         type: boolean
-      mdsteps_rigid:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool1:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool2:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool3:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      timestep:
-        default: 0.002
-        type: number
-        maximum: 9999
-        minimum: -9999
-      tadfactor:
-        default: 8
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_rigid_init:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_rigid_final:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool2_init:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool2_final:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool3_init:
-        default: 0.05
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool3_final:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_high:
-        default: 2000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool1_init:
-        default: 2000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool1_final:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool2_init:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool2_final:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool3_init:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool3_final:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
       prot_segid_1:
         default: A
         type: string
@@ -4001,62 +4358,17 @@ nodes:
       shape_20:
         default: false
         type: boolean
-      amb_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      amb_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      amb_cool2:
+      amb_scale:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      amb_cool3:
+      unamb_scale:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      unamb_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool3:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool3:
+      hbond_scale:
         default: 50
         type: number
         maximum: 9999
@@ -4069,86 +4381,6 @@ nodes:
         type: boolean
       ncvpart:
         default: 2
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_hot:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool1:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool2:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool3:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_hot:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool1:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool2:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool3:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_hot:
-        default: -1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool1:
-        default: -1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool2:
-        default: -0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool3:
-        default: -0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_hot:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool1:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool2:
-        default: 0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool3:
-        default: 0.1
         type: number
         maximum: 9999
         minimum: -9999
@@ -4177,22 +4409,7 @@ nodes:
       dihedrals_on:
         default: false
         type: boolean
-      dihedrals_hot:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool1:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool3:
+      dihedrals_scale:
         default: 200
         type: number
         maximum: 9999
@@ -5172,7 +5389,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_bsa:
-        default: -0.01
+        default: 0.0
         type: number
         maximum: 9999
         minimum: -9999
@@ -5202,7 +5419,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_elec:
-        default: 1.0
+        default: 0.2
         type: number
         maximum: 9999
         minimum: -9999
@@ -5255,7 +5472,7 @@ nodes:
         default: true
         type: boolean
       dielec:
-        default: rdie
+        default: cdie
         type: string
         minLength: 0
         maxLength: 100
@@ -8766,10 +8983,10 @@ nodes:
       ui:widget: file
     ligand_top_fname:
       ui:widget: file
-- id: emref
+- id: flexref
   category: refinement
-  label: HADDOCK3 module for energy minimization refinement.
-  description: HADDOCK3 module energy minimization refinement.
+  label: HADDOCK3 module for flexible refinement.
+  description: HADDOCK3 module for flexible refinement.
   schema:
     type: object
     properties:
@@ -8801,18 +9018,8 @@ nodes:
       ligand_top_fname:
         type: string
         format: uri-reference
-      sampling:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
       sampling_factor:
         default: 1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      nemsteps:
-        default: 200
         type: number
         maximum: 9999
         minimum: -9999
@@ -8824,6 +9031,101 @@ nodes:
       keepwater:
         default: false
         type: boolean
+      mdsteps_rigid:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool1:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool2:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool3:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      timestep:
+        default: 0.002
+        type: number
+        maximum: 9999
+        minimum: -9999
+      tadfactor:
+        default: 8
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_rigid_init:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_rigid_final:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool2_init:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool2_final:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool3_init:
+        default: 0.05
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool3_final:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_high:
+        default: 2000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool1_init:
+        default: 2000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool1_final:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool2_init:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool2_final:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool3_init:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool3_final:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
       prot_segid_1:
         default: A
         type: string
@@ -8984,17 +9286,62 @@ nodes:
       shape_20:
         default: false
         type: boolean
-      amb_scale:
+      amb_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      amb_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      amb_cool2:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      unamb_scale:
+      amb_cool3:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      hbond_scale:
+      unamb_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool3:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool3:
         default: 50
         type: number
         maximum: 9999
@@ -9007,6 +9354,86 @@ nodes:
         type: boolean
       ncvpart:
         default: 2
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_hot:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool1:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool2:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool3:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_hot:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool1:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool2:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool3:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_hot:
+        default: -1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool1:
+        default: -1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool2:
+        default: -0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool3:
+        default: -0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_hot:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool1:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool2:
+        default: 0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool3:
+        default: 0.1
         type: number
         maximum: 9999
         minimum: -9999
@@ -9035,7 +9462,22 @@ nodes:
       dihedrals_on:
         default: false
         type: boolean
-      dihedrals_scale:
+      dihedrals_hot:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool1:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool3:
         default: 200
         type: number
         maximum: 9999
@@ -10015,7 +10457,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_bsa:
-        default: 0.0
+        default: -0.01
         type: number
         maximum: 9999
         minimum: -9999
@@ -10045,7 +10487,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_elec:
-        default: 0.2
+        default: 1.0
         type: number
         maximum: 9999
         minimum: -9999
@@ -10098,7 +10540,7 @@ nodes:
         default: true
         type: boolean
       dielec:
-        default: cdie
+        default: rdie
         type: string
         minLength: 0
         maxLength: 100
@@ -11176,6 +11618,210 @@ nodes:
       ui:widget: file
     hbond_fname:
       ui:widget: file
+    ligand_param_fname:
+      ui:widget: file
+    ligand_top_fname:
+      ui:widget: file
+- id: emscoring
+  category: scoring
+  label: HADDOCK3 scoring module.
+  description: HADDOCK3 module to perform energy minimization scoring.
+  schema:
+    type: object
+    properties:
+      tolerance:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      log_level:
+        default: verbose
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_param_fname:
+        type: string
+        format: uri-reference
+      ligand_top_fname:
+        type: string
+        format: uri-reference
+      individualize:
+        default: true
+        type: boolean
+      nemsteps:
+        default: 40
+        type: number
+        maximum: 9999
+        minimum: -9999
+      elecflag:
+        default: true
+        type: boolean
+      dielec:
+        default: cdie
+        type: string
+        minLength: 0
+        maxLength: 100
+      epsilon:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedflag:
+        default: true
+        type: boolean
+      par_nonbonded:
+        default: OPLSX
+        type: string
+        minLength: 0
+        maxLength: 100
+      w_air:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_bsa:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_cdih:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_dani:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_deint:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_desolv:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_dist:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_elec:
+        default: 0.2
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_lcc:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_rg:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_sani:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_sym:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_vdw:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_vean:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_xpcs:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_xrdc:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_zres:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      shape_1:
+        default: false
+        type: boolean
+      shape_2:
+        default: false
+        type: boolean
+      shape_3:
+        default: false
+        type: boolean
+      shape_4:
+        default: false
+        type: boolean
+      shape_5:
+        default: false
+        type: boolean
+      shape_6:
+        default: false
+        type: boolean
+      shape_7:
+        default: false
+        type: boolean
+      shape_8:
+        default: false
+        type: boolean
+      shape_9:
+        default: false
+        type: boolean
+      shape_10:
+        default: false
+        type: boolean
+      shape_11:
+        default: false
+        type: boolean
+      shape_12:
+        default: false
+        type: boolean
+      shape_13:
+        default: false
+        type: boolean
+      shape_14:
+        default: false
+        type: boolean
+      shape_15:
+        default: false
+        type: boolean
+      shape_16:
+        default: false
+        type: boolean
+      shape_17:
+        default: false
+        type: boolean
+      shape_18:
+        default: false
+        type: boolean
+      shape_19:
+        default: false
+        type: boolean
+      shape_20:
+        default: false
+        type: boolean
+    required: []
+    additionalProperties: false
+  uiSchema:
     ligand_param_fname:
       ui:widget: file
     ligand_top_fname:

--- a/public/catalog/haddock3.guru.yaml
+++ b/public/catalog/haddock3.guru.yaml
@@ -1,15 +1,15 @@
 title: Haddock 3 on guru level
 categories:
-- name: refinement
-  description: HADDOCK3 actions referring to refinement.
-- name: sampling
-  description: HADDOCK3 modules for sampling.
-- name: analysis
-  description: HADDOCK3 modules related to model analysis.
-- name: scoring
-  description: HADDOCK3 modules to score modules.
 - name: topology
   description: HADDOCK3 modules to create topologies.
+- name: sampling
+  description: HADDOCK3 modules for sampling.
+- name: refinement
+  description: HADDOCK3 actions referring to refinement.
+- name: scoring
+  description: HADDOCK3 modules to score modules.
+- name: analysis
+  description: HADDOCK3 modules related to model analysis.
 global:
   schema:
     type: object
@@ -82,78 +82,1585 @@ global:
     cns_exec:
       ui:widget: file
 nodes:
-- id: clustfcc
-  category: analysis
-  label: HADDOCK3 FCC clustering module.
-  description: HADDOCK3 module for clustering with FCC.
+- id: topoaa
+  category: topology
+  label: Create and manage CNS all-atom topology.
+  description: HADDOCK3 module to create CNS all-atom topologies.
   schema:
     type: object
     properties:
-      executable:
-        default: src/contact_fcc
+      autohis:
+        default: true
+        title: Automatic HIS protonation state
+        description: 'The protonation state of histidine (+1: HIS or 0: HISD/HISE)
+          will be automatically set by HADDOCK'
+        $comment: 'If set to true, HADDOCK will automatically define the protonation
+          state of histidines ((+1: HIS or 0: HISD/HISE) by selecting the state leading
+          to the lowest electrostatic energy'
+        type: boolean
+      delenph:
+        default: true
+        title: Keep or remove non-polar hydrogen atoms
+        description: If set to true, non-polar hydrogen atoms will be discarded to
+          save computing time
+        $comment: Since HADDOCK uses a united atom force field, the non-polar hydrogen
+          atoms can be in principle discarded. This saves computing time. However
+          this should not be done if you are defining distance restraints to specific
+          hydrogen atoms (e.g. when using NMR distance restraints).
+        type: boolean
+      log_level:
+        default: verbose
+        title: Log level verbosity for CNS
+        description: Set the log level verbosity for CNS (minimal or verbose)
+        $comment: CNS, the computational engine used by HADDOCK can generate a lot
+          of output messages. This parameter controls the verbosity of CNS (minimal
+          or verbose)
+        type: string
+        minLength: 0
+        maxLength: 100
+      iniseed:
+        default: 917
+        title: Random seed
+        description: Random seed used in CNS to initialize the random seed function
+        $comment: Random seed used in CNS to initialize the random seed function
+        type: number
+        maximum: 9999999999999999
+        minimum: 0
+      ligand_top_fname:
+        title: Custom ligand topology file
+        description: Ligand topology file in CNS format
+        $comment: Ligand topology file in CNS format containing the ligand topologies
+          (atoms, masses, charges, bond definitions...) for any ligand not supported
+          by default by HADDOCK
         type: string
         format: uri-reference
-      contact_distance_cutoff:
-        default: 5.0
+      limit:
+        default: true
+        type: boolean
+      tolerance:
+        default: 0
+        title: Failure tolerance percentage
+        description: Percentage of allowed failures for a module to successfully complete
+        $comment: Percentage of allowed failures for a module to successfully complete
         type: number
-        maximum: 9999
-        minimum: -9999
-      fraction_cutoff:
-        default: 0.6
-        type: number
-        maximum: 9999
-        minimum: -9999
-      threshold:
-        default: 4
-        type: number
-        maximum: 9999
-        minimum: -9999
-      strictness:
-        default: 0.75
-        type: number
-        maximum: 9999
-        minimum: -9999
+        maximum: 99
+        minimum: 0
+      mol1:
+        type: object
+        properties:
+          prot_segid:
+            default: A
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol2:
+        type: object
+        properties:
+          prot_segid:
+            default: B
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol3:
+        type: object
+        properties:
+          prot_segid:
+            default: C
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol4:
+        type: object
+        properties:
+          prot_segid:
+            default: D
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol5:
+        type: object
+        properties:
+          prot_segid:
+            default: E
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol6:
+        type: object
+        properties:
+          prot_segid:
+            default: F
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol7:
+        type: object
+        properties:
+          prot_segid:
+            default: G
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol8:
+        type: object
+        properties:
+          prot_segid:
+            default: H
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol9:
+        type: object
+        properties:
+          prot_segid:
+            default: I
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol10:
+        type: object
+        properties:
+          prot_segid:
+            default: J
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol11:
+        type: object
+        properties:
+          prot_segid:
+            default: K
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol12:
+        type: object
+        properties:
+          prot_segid:
+            default: L
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol13:
+        type: object
+        properties:
+          prot_segid:
+            default: M
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol14:
+        type: object
+        properties:
+          prot_segid:
+            default: N
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol15:
+        type: object
+        properties:
+          prot_segid:
+            default: O
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol16:
+        type: object
+        properties:
+          prot_segid:
+            default: P
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol17:
+        type: object
+        properties:
+          prot_segid:
+            default: Q
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol18:
+        type: object
+        properties:
+          prot_segid:
+            default: R
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol19:
+        type: object
+        properties:
+          prot_segid:
+            default: S
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
+      mol20:
+        type: object
+        properties:
+          prot_segid:
+            default: T
+            title: Segment ID
+            description: Segment ID assigned to this molecule
+            $comment: Segment ID assigned to this molecule in CNS. Used to distinguish
+              different molecules
+            type: string
+            minLength: 0
+            maxLength: 4
+          cyclicpept:
+            default: false
+            title: Cyclic peptide
+            description: Defines the molecule as a cyclic peptide
+            $comment: This option defines the molecule as a cyclic peptide and HADDOCK
+              will generate a peptide bond between the N- and C-ter provided those
+              are within 2A. This cutoff can be changed in the generate-topology.cns
+              script.
+            type: boolean
+          nhisd:
+            default: 0
+            title: Number of HISD residue
+            description: Defines the number of HISD residues (neutral HIS with the
+              proton on the ND atom) residues when autohis=false
+            $comment: Defines the number of HISD residues (neutral HIS with the proton
+              on the ND atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hisd_1, hisd_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hisd_1:
+            title: HISD residue number
+            description: Residue number of the Histidine to be defined as HISD
+            $comment: Residue number of the Histidine to be defined as HISD
+            type: number
+            maximum: 9999
+            minimum: -9999
+          nhise:
+            default: 0
+            title: Number of HISE residue
+            description: Defines the number of HISE residues (neutral HIS with the
+              proton on the NE atom) residues when autohis=false
+            $comment: Defines the number of HISE residues (neutral HIS with the proton
+              on the NE atom) residues. The corresponding residue numbers must be
+              defined in the following parameter (hise_1, hise_2, ...). Add as many
+              as needed. Note that HIS is interpreted as a charged Histidine)
+            type: number
+            maximum: 9999
+            minimum: 0
+          hise_1:
+            title: HISE residue number
+            description: Residue number of the Histidine to be defined as HISE
+            $comment: Residue number of the Histidine to be defined as HISE
+            type: number
+            maximum: 9999
+            minimum: -9999
+        required: []
+        additionalProperties: false
     required: []
     additionalProperties: false
   uiSchema:
-    executable:
+    autohis:
+      ui:group: molecule
+    delenph:
+      ui:group: molecule
+    log_level:
+      ui:group: module
+    iniseed:
+      ui:group: molecule
+    ligand_top_fname:
       ui:widget: file
-- id: seletop
-  category: analysis
-  label: HADDOCK3 module to select a top cluster/model.
-  description: HADDOCK3 module to select top cluster/model.
-  schema:
-    type: object
-    properties:
-      select:
-        default: 200
-        type: number
-        maximum: 9999
-        minimum: -9999
-    required: []
-    additionalProperties: false
-  uiSchema: {}
-- id: seletopclusts
-  category: analysis
-  label: HADDOCK3 module to select a top cluster/model.
-  description: Haddock Module for 'seletopclusts'.
-  schema:
-    type: object
-    properties:
-      top_cluster:
-        default: []
-        type: array
-        minItems: 0
-        maxItems: 100
-        items:
-          type: number
-      top_models:
-        type: number
-        maximum: 9999
-        minimum: -9999
-    required: []
-    additionalProperties: false
-  uiSchema: {}
+      ui:group: force field
+    tolerance:
+      ui:group: module
+    mol1:
+      mol1:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol2:
+      mol2:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol3:
+      mol3:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol4:
+      mol4:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol5:
+      mol5:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol6:
+      mol6:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol7:
+      mol7:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol8:
+      mol8:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol9:
+      mol9:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol10:
+      mol10:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol11:
+      mol11:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol12:
+      mol12:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol13:
+      mol13:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol14:
+      mol14:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol15:
+      mol15:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol16:
+      mol16:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol17:
+      mol17:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol18:
+      mol18:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol19:
+      mol19:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
+    mol20:
+      mol20:
+        prot_segid:
+          ui:group: molecule
+        cyclicpept:
+          ui:group: molecule
+        nhisd:
+          ui:group: molecule
+        hisd_1:
+          ui:group: molecule
+        nhise:
+          ui:group: molecule
+        hise_1:
+          ui:group: molecule
 - id: caprieval
   category: analysis
   label: Calculate CAPRI metrics.
@@ -235,6 +1742,152 @@ nodes:
   uiSchema:
     reference_fname:
       ui:widget: file
+- id: seletop
+  category: analysis
+  label: HADDOCK3 module to select a top cluster/model.
+  description: HADDOCK3 module to select top cluster/model.
+  schema:
+    type: object
+    properties:
+      select:
+        default: 200
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema: {}
+- id: clustfcc
+  category: analysis
+  label: HADDOCK3 FCC clustering module.
+  description: HADDOCK3 module for clustering with FCC.
+  schema:
+    type: object
+    properties:
+      executable:
+        default: src/contact_fcc
+        type: string
+        format: uri-reference
+      contact_distance_cutoff:
+        default: 5.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      fraction_cutoff:
+        default: 0.6
+        type: number
+        maximum: 9999
+        minimum: -9999
+      threshold:
+        default: 4
+        type: number
+        maximum: 9999
+        minimum: -9999
+      strictness:
+        default: 0.75
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema:
+    executable:
+      ui:widget: file
+- id: seletopclusts
+  category: analysis
+  label: HADDOCK3 module to select a top cluster/model.
+  description: Haddock Module for 'seletopclusts'.
+  schema:
+    type: object
+    properties:
+      top_cluster:
+        default: []
+        type: array
+        minItems: 0
+        maxItems: 100
+        items:
+          type: number
+      top_models:
+        type: number
+        maximum: 9999
+        minimum: -9999
+    required: []
+    additionalProperties: false
+  uiSchema: {}
+- id: lightdock
+  category: sampling
+  label: Run Lightdock as a HADDOCK3 module.
+  description: HADDOCK3 Lightdock module.
+  schema:
+    type: object
+    properties:
+      glowworms:
+        default: 200
+        type: number
+        maximum: 9999
+        minimum: -9999
+      steps:
+        default: 100
+        type: number
+        maximum: 9999
+        minimum: -9999
+      swarms:
+        default: 400
+        type: number
+        maximum: 9999
+        minimum: -9999
+      scoring:
+        default: fastdfire
+        type: string
+        minLength: 0
+        maxLength: 100
+      top:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      receptor_chains:
+        default: A
+        type: string
+        minLength: 0
+        maxLength: 100
+      receptor_active:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      receptor_passive:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_chains:
+        default: B
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_active:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_passive:
+        default: ''
+        type: string
+        minLength: 0
+        maxLength: 100
+      noxt:
+        default: true
+        type: boolean
+      noh:
+        default: true
+        type: boolean
+      restraints:
+        default: false
+        type: boolean
+    required: []
+    additionalProperties: false
+  uiSchema: {}
 - id: gdock
   category: sampling
   label: HADDOCK3 gdock integration module.
@@ -2509,1221 +4162,10 @@ nodes:
       ui:widget: file
     ligand_top_fname:
       ui:widget: file
-- id: lightdock
-  category: sampling
-  label: Run Lightdock as a HADDOCK3 module.
-  description: HADDOCK3 Lightdock module.
-  schema:
-    type: object
-    properties:
-      glowworms:
-        default: 200
-        type: number
-        maximum: 9999
-        minimum: -9999
-      steps:
-        default: 100
-        type: number
-        maximum: 9999
-        minimum: -9999
-      swarms:
-        default: 400
-        type: number
-        maximum: 9999
-        minimum: -9999
-      scoring:
-        default: fastdfire
-        type: string
-        minLength: 0
-        maxLength: 100
-      top:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      receptor_chains:
-        default: A
-        type: string
-        minLength: 0
-        maxLength: 100
-      receptor_active:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      receptor_passive:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_chains:
-        default: B
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_active:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_passive:
-        default: ''
-        type: string
-        minLength: 0
-        maxLength: 100
-      noxt:
-        default: true
-        type: boolean
-      noh:
-        default: true
-        type: boolean
-      restraints:
-        default: false
-        type: boolean
-    required: []
-    additionalProperties: false
-  uiSchema: {}
-- id: topoaa
-  category: topology
-  label: Create and manage CNS all-atom topology.
-  description: HADDOCK3 module to create CNS all-atom topologies.
-  schema:
-    type: object
-    properties:
-      autohis:
-        default: true
-        title: Automatic HIS protonation state
-        description: 'The protonation state of histidine (+1: HIS or 0: HISD/HISE)
-          will be automatically set by HADDOCK'
-        $comment: 'If set to true, HADDOCK will automatically define the protonation
-          state of histidines ((+1: HIS or 0: HISD/HISE) by selecting the state leading
-          to the lowest electrostatic energy'
-        type: boolean
-      delenph:
-        default: true
-        title: Keep or remove non-polar hydrogen atoms
-        description: If set to true, non-polar hydrogen atoms will be discarded to
-          save computing time
-        $comment: Since HADDOCK uses a united atom force field, the non-polar hydrogen
-          atoms can be in principle discarded. This saves computing time. However
-          this should not be done if you are defining distance restraints to specific
-          hydrogen atoms (e.g. when using NMR distance restraints).
-        type: boolean
-      log_level:
-        default: verbose
-        title: Log level verbosity for CNS
-        description: Set the log level verbosity for CNS (minimal or verbose)
-        $comment: CNS, the computational engine used by HADDOCK can generate a lot
-          of output messages. This parameter controls the verbosity of CNS (minimal
-          or verbose)
-        type: string
-        minLength: 0
-        maxLength: 100
-      iniseed:
-        default: 917
-        title: Random seed
-        description: Random seed used in CNS to initialize the random seed function
-        $comment: Random seed used in CNS to initialize the random seed function
-        type: number
-        maximum: 9999999999999999
-        minimum: 0
-      ligand_param_fname:
-        type: string
-        format: uri-reference
-      ligand_top_fname:
-        type: string
-        format: uri-reference
-      limit:
-        default: true
-        type: boolean
-      tolerance:
-        default: 0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mol1:
-        type: object
-        properties:
-          prot_segid:
-            default: A
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol2:
-        type: object
-        properties:
-          prot_segid:
-            default: B
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol3:
-        type: object
-        properties:
-          prot_segid:
-            default: C
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol4:
-        type: object
-        properties:
-          prot_segid:
-            default: D
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol5:
-        type: object
-        properties:
-          prot_segid:
-            default: E
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol6:
-        type: object
-        properties:
-          prot_segid:
-            default: F
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol7:
-        type: object
-        properties:
-          prot_segid:
-            default: G
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol8:
-        type: object
-        properties:
-          prot_segid:
-            default: H
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol9:
-        type: object
-        properties:
-          prot_segid:
-            default: I
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol10:
-        type: object
-        properties:
-          prot_segid:
-            default: J
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol11:
-        type: object
-        properties:
-          prot_segid:
-            default: K
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol12:
-        type: object
-        properties:
-          prot_segid:
-            default: L
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol13:
-        type: object
-        properties:
-          prot_segid:
-            default: M
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol14:
-        type: object
-        properties:
-          prot_segid:
-            default: N
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol15:
-        type: object
-        properties:
-          prot_segid:
-            default: O
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol16:
-        type: object
-        properties:
-          prot_segid:
-            default: P
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol17:
-        type: object
-        properties:
-          prot_segid:
-            default: Q
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol18:
-        type: object
-        properties:
-          prot_segid:
-            default: R
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol19:
-        type: object
-        properties:
-          prot_segid:
-            default: S
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-      mol20:
-        type: object
-        properties:
-          prot_segid:
-            default: T
-            type: string
-            minLength: 0
-            maxLength: 100
-          fix_origin:
-            default: false
-            type: boolean
-          dna:
-            default: false
-            type: boolean
-          shape:
-            default: false
-            type: boolean
-          cg:
-            default: false
-            type: boolean
-          cyclicpept:
-            default: false
-            type: boolean
-          nhisd:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hisd_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-          nhise:
-            default: 0
-            type: number
-            maximum: 9999
-            minimum: -9999
-          hise_1:
-            type: number
-            maximum: 9999
-            minimum: -9999
-        required: []
-        additionalProperties: false
-    required: []
-    additionalProperties: false
-  uiSchema:
-    autohis:
-      ui:group: molecule
-    delenph:
-      ui:group: molecule
-    log_level:
-      ui:group: module
-    iniseed:
-      ui:group: molecule
-    ligand_param_fname:
-      ui:widget: file
-    ligand_top_fname:
-      ui:widget: file
-- id: emscoring
-  category: scoring
-  label: HADDOCK3 scoring module.
-  description: HADDOCK3 module to perform energy minimization scoring.
-  schema:
-    type: object
-    properties:
-      tolerance:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      log_level:
-        default: verbose
-        type: string
-        minLength: 0
-        maxLength: 100
-      ligand_param_fname:
-        type: string
-        format: uri-reference
-      ligand_top_fname:
-        type: string
-        format: uri-reference
-      individualize:
-        default: true
-        type: boolean
-      nemsteps:
-        default: 40
-        type: number
-        maximum: 9999
-        minimum: -9999
-      elecflag:
-        default: true
-        type: boolean
-      dielec:
-        default: cdie
-        type: string
-        minLength: 0
-        maxLength: 100
-      epsilon:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedflag:
-        default: true
-        type: boolean
-      par_nonbonded:
-        default: OPLSX
-        type: string
-        minLength: 0
-        maxLength: 100
-      w_air:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_bsa:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_cdih:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_dani:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_deint:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_desolv:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_dist:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_elec:
-        default: 0.2
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_lcc:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_rg:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_sani:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_sym:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_vdw:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_vean:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_xpcs:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_xrdc:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      w_zres:
-        default: 0.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      shape_1:
-        default: false
-        type: boolean
-      shape_2:
-        default: false
-        type: boolean
-      shape_3:
-        default: false
-        type: boolean
-      shape_4:
-        default: false
-        type: boolean
-      shape_5:
-        default: false
-        type: boolean
-      shape_6:
-        default: false
-        type: boolean
-      shape_7:
-        default: false
-        type: boolean
-      shape_8:
-        default: false
-        type: boolean
-      shape_9:
-        default: false
-        type: boolean
-      shape_10:
-        default: false
-        type: boolean
-      shape_11:
-        default: false
-        type: boolean
-      shape_12:
-        default: false
-        type: boolean
-      shape_13:
-        default: false
-        type: boolean
-      shape_14:
-        default: false
-        type: boolean
-      shape_15:
-        default: false
-        type: boolean
-      shape_16:
-        default: false
-        type: boolean
-      shape_17:
-        default: false
-        type: boolean
-      shape_18:
-        default: false
-        type: boolean
-      shape_19:
-        default: false
-        type: boolean
-      shape_20:
-        default: false
-        type: boolean
-    required: []
-    additionalProperties: false
-  uiSchema:
-    ligand_param_fname:
-      ui:widget: file
-    ligand_top_fname:
-      ui:widget: file
-- id: flexref
+- id: emref
   category: refinement
-  label: HADDOCK3 module for flexible refinement.
-  description: HADDOCK3 module for flexible refinement.
+  label: HADDOCK3 module for energy minimization refinement.
+  description: HADDOCK3 module energy minimization refinement.
   schema:
     type: object
     properties:
@@ -3755,8 +4197,18 @@ nodes:
       ligand_top_fname:
         type: string
         format: uri-reference
+      sampling:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
       sampling_factor:
         default: 1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      nemsteps:
+        default: 200
         type: number
         maximum: 9999
         minimum: -9999
@@ -3768,101 +4220,6 @@ nodes:
       keepwater:
         default: false
         type: boolean
-      mdsteps_rigid:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool1:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool2:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mdsteps_cool3:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      timestep:
-        default: 0.002
-        type: number
-        maximum: 9999
-        minimum: -9999
-      tadfactor:
-        default: 8
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_rigid_init:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_rigid_final:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool2_init:
-        default: 0.001
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool2_final:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool3_init:
-        default: 0.05
-        type: number
-        maximum: 9999
-        minimum: -9999
-      sinter_cool3_final:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_high:
-        default: 2000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool1_init:
-        default: 2000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool1_final:
-        default: 500
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool2_init:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool2_final:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool3_init:
-        default: 1000
-        type: number
-        maximum: 9999
-        minimum: -9999
-      temp_cool3_final:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
       prot_segid_1:
         default: A
         type: string
@@ -4023,62 +4380,17 @@ nodes:
       shape_20:
         default: false
         type: boolean
-      amb_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      amb_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      amb_cool2:
+      amb_scale:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      amb_cool3:
+      unamb_scale:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      unamb_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      unamb_cool3:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_hot:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool1:
-        default: 10
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      hbond_cool3:
+      hbond_scale:
         default: 50
         type: number
         maximum: 9999
@@ -4091,86 +4403,6 @@ nodes:
         type: boolean
       ncvpart:
         default: 2
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_hot:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool1:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool2:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      mrswi_cool3:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_hot:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool1:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool2:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      rswi_cool3:
-        default: 0.5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_hot:
-        default: -1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool1:
-        default: -1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool2:
-        default: -0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      masy_cool3:
-        default: -0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_hot:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool1:
-        default: 1.0
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool2:
-        default: 0.1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      asy_cool3:
-        default: 0.1
         type: number
         maximum: 9999
         minimum: -9999
@@ -4199,22 +4431,7 @@ nodes:
       dihedrals_on:
         default: false
         type: boolean
-      dihedrals_hot:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool1:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool2:
-        default: 50
-        type: number
-        maximum: 9999
-        minimum: -9999
-      dihedrals_cool3:
+      dihedrals_scale:
         default: 200
         type: number
         maximum: 9999
@@ -5194,7 +5411,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_bsa:
-        default: -0.01
+        default: 0.0
         type: number
         maximum: 9999
         minimum: -9999
@@ -5224,7 +5441,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_elec:
-        default: 1.0
+        default: 0.2
         type: number
         maximum: 9999
         minimum: -9999
@@ -5277,7 +5494,7 @@ nodes:
         default: true
         type: boolean
       dielec:
-        default: rdie
+        default: cdie
         type: string
         minLength: 0
         maxLength: 100
@@ -8788,10 +9005,10 @@ nodes:
       ui:widget: file
     ligand_top_fname:
       ui:widget: file
-- id: emref
+- id: flexref
   category: refinement
-  label: HADDOCK3 module for energy minimization refinement.
-  description: HADDOCK3 module energy minimization refinement.
+  label: HADDOCK3 module for flexible refinement.
+  description: HADDOCK3 module for flexible refinement.
   schema:
     type: object
     properties:
@@ -8823,18 +9040,8 @@ nodes:
       ligand_top_fname:
         type: string
         format: uri-reference
-      sampling:
-        default: 5
-        type: number
-        maximum: 9999
-        minimum: -9999
       sampling_factor:
         default: 1
-        type: number
-        maximum: 9999
-        minimum: -9999
-      nemsteps:
-        default: 200
         type: number
         maximum: 9999
         minimum: -9999
@@ -8846,6 +9053,101 @@ nodes:
       keepwater:
         default: false
         type: boolean
+      mdsteps_rigid:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool1:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool2:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mdsteps_cool3:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      timestep:
+        default: 0.002
+        type: number
+        maximum: 9999
+        minimum: -9999
+      tadfactor:
+        default: 8
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_rigid_init:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_rigid_final:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool2_init:
+        default: 0.001
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool2_final:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool3_init:
+        default: 0.05
+        type: number
+        maximum: 9999
+        minimum: -9999
+      sinter_cool3_final:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_high:
+        default: 2000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool1_init:
+        default: 2000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool1_final:
+        default: 500
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool2_init:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool2_final:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool3_init:
+        default: 1000
+        type: number
+        maximum: 9999
+        minimum: -9999
+      temp_cool3_final:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
       prot_segid_1:
         default: A
         type: string
@@ -9006,17 +9308,62 @@ nodes:
       shape_20:
         default: false
         type: boolean
-      amb_scale:
+      amb_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      amb_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      amb_cool2:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      unamb_scale:
+      amb_cool3:
         default: 50
         type: number
         maximum: 9999
         minimum: -9999
-      hbond_scale:
+      unamb_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      unamb_cool3:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_hot:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool1:
+        default: 10
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      hbond_cool3:
         default: 50
         type: number
         maximum: 9999
@@ -9029,6 +9376,86 @@ nodes:
         type: boolean
       ncvpart:
         default: 2
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_hot:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool1:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool2:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      mrswi_cool3:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_hot:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool1:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool2:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      rswi_cool3:
+        default: 0.5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_hot:
+        default: -1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool1:
+        default: -1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool2:
+        default: -0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      masy_cool3:
+        default: -0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_hot:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool1:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool2:
+        default: 0.1
+        type: number
+        maximum: 9999
+        minimum: -9999
+      asy_cool3:
+        default: 0.1
         type: number
         maximum: 9999
         minimum: -9999
@@ -9057,7 +9484,22 @@ nodes:
       dihedrals_on:
         default: false
         type: boolean
-      dihedrals_scale:
+      dihedrals_hot:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool1:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool2:
+        default: 50
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedrals_cool3:
         default: 200
         type: number
         maximum: 9999
@@ -10037,7 +10479,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_bsa:
-        default: 0.0
+        default: -0.01
         type: number
         maximum: 9999
         minimum: -9999
@@ -10067,7 +10509,7 @@ nodes:
         maximum: 9999
         minimum: -9999
       w_elec:
-        default: 0.2
+        default: 1.0
         type: number
         maximum: 9999
         minimum: -9999
@@ -10120,7 +10562,7 @@ nodes:
         default: true
         type: boolean
       dielec:
-        default: cdie
+        default: rdie
         type: string
         minLength: 0
         maxLength: 100
@@ -11198,6 +11640,210 @@ nodes:
       ui:widget: file
     hbond_fname:
       ui:widget: file
+    ligand_param_fname:
+      ui:widget: file
+    ligand_top_fname:
+      ui:widget: file
+- id: emscoring
+  category: scoring
+  label: HADDOCK3 scoring module.
+  description: HADDOCK3 module to perform energy minimization scoring.
+  schema:
+    type: object
+    properties:
+      tolerance:
+        default: 5
+        type: number
+        maximum: 9999
+        minimum: -9999
+      log_level:
+        default: verbose
+        type: string
+        minLength: 0
+        maxLength: 100
+      ligand_param_fname:
+        type: string
+        format: uri-reference
+      ligand_top_fname:
+        type: string
+        format: uri-reference
+      individualize:
+        default: true
+        type: boolean
+      nemsteps:
+        default: 40
+        type: number
+        maximum: 9999
+        minimum: -9999
+      elecflag:
+        default: true
+        type: boolean
+      dielec:
+        default: cdie
+        type: string
+        minLength: 0
+        maxLength: 100
+      epsilon:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      dihedflag:
+        default: true
+        type: boolean
+      par_nonbonded:
+        default: OPLSX
+        type: string
+        minLength: 0
+        maxLength: 100
+      w_air:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_bsa:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_cdih:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_dani:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_deint:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_desolv:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_dist:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_elec:
+        default: 0.2
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_lcc:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_rg:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_sani:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_sym:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_vdw:
+        default: 1.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_vean:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_xpcs:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_xrdc:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      w_zres:
+        default: 0.0
+        type: number
+        maximum: 9999
+        minimum: -9999
+      shape_1:
+        default: false
+        type: boolean
+      shape_2:
+        default: false
+        type: boolean
+      shape_3:
+        default: false
+        type: boolean
+      shape_4:
+        default: false
+        type: boolean
+      shape_5:
+        default: false
+        type: boolean
+      shape_6:
+        default: false
+        type: boolean
+      shape_7:
+        default: false
+        type: boolean
+      shape_8:
+        default: false
+        type: boolean
+      shape_9:
+        default: false
+        type: boolean
+      shape_10:
+        default: false
+        type: boolean
+      shape_11:
+        default: false
+        type: boolean
+      shape_12:
+        default: false
+        type: boolean
+      shape_13:
+        default: false
+        type: boolean
+      shape_14:
+        default: false
+        type: boolean
+      shape_15:
+        default: false
+        type: boolean
+      shape_16:
+        default: false
+        type: boolean
+      shape_17:
+        default: false
+        type: boolean
+      shape_18:
+        default: false
+        type: boolean
+      shape_19:
+        default: false
+        type: boolean
+      shape_20:
+        default: false
+        type: boolean
+    required: []
+    additionalProperties: false
+  uiSchema:
     ligand_param_fname:
       ui:widget: file
     ligand_top_fname:


### PR DESCRIPTION
The order in which the category of the nodes is shown is arbitrary, but it makes sense from them to be presented in a specific order.

This PR adds the order to the `generate_haddock3_catalog.py` script also updates the catalogs with the latest changes.