### PR TITLE
Checkbox widget should have a description field.

### DIFF
--- a/src/CheckboxWidget.stories.tsx
+++ b/src/CheckboxWidget.stories.tsx
@@ -1,0 +1,52 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { CollapsibleField } from './CollapsibleField'
+import { action } from '@storybook/addon-actions'
+import { Form } from './Form'
+import { JSONSchema7 } from 'json-schema'
+import { UiSchema } from '@rjsf/core'
+
+
+const meta: ComponentMeta<typeof CollapsibleField> = {
+    title: 'CollapsibleField',
+    component: CollapsibleField
+  }
+
+  export default meta
+
+  function render (schema: JSONSchema7, uiSchema: UiSchema): JSX.Element {
+    const fields = {
+      collapsible: CollapsibleField
+    }
+    return (
+      <Form
+        fields={fields}
+        schema={schema}
+        uiSchema={uiSchema}
+        onSubmit={action('onSubmit')}
+      />
+    )
+  }
+
+
+export const CheckboxWidget: ComponentStory<typeof Form> = () => {
+    const schema: JSONSchema7 = {
+        "type": "object",
+        "title": "Boolean field",
+        "properties": {
+            "default": {
+            "type": "boolean",
+            "title": "checkbox (default)",
+            "description": "This is the checkbox-description"
+            }
+        },
+      additionalProperties: false
+    }
+    const uiSchema = {
+      group1: {
+        'ui:field': 'collapsible'
+      }
+    }
+    return render(schema, uiSchema)
+  }
+
+

--- a/src/CheckboxWidget.stories.tsx
+++ b/src/CheckboxWidget.stories.tsx
@@ -1,52 +1,43 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react'
-import { CollapsibleField } from './CollapsibleField'
 import { action } from '@storybook/addon-actions'
 import { Form } from './Form'
 import { JSONSchema7 } from 'json-schema'
-import { UiSchema } from '@rjsf/core'
+import { Widgets } from '@rjsf/bootstrap-4/'
 
 
-const meta: ComponentMeta<typeof CollapsibleField> = {
-    title: 'CollapsibleField',
-    component: CollapsibleField
-  }
+const meta: ComponentMeta<typeof Widgets.CheckboxWidget> = {
+  title: 'Checkbox',
+  component: Widgets.CheckboxWidget
+}
 
-  export default meta
+export default meta
 
-  function render (schema: JSONSchema7, uiSchema: UiSchema): JSX.Element {
-    const fields = {
-      collapsible: CollapsibleField
-    }
-    return (
-      <Form
-        fields={fields}
-        schema={schema}
-        uiSchema={uiSchema}
-        onSubmit={action('onSubmit')}
-      />
-    )
-  }
+function render(schema: JSONSchema7): JSX.Element {
+  debugger
+  return (
+    <Form
+      schema={schema}
+      onSubmit={action('onSubmit')}
+    />
+  )
+}
 
 
 export const CheckboxWidget: ComponentStory<typeof Form> = () => {
-    const schema: JSONSchema7 = {
-        "type": "object",
-        "title": "Boolean field",
-        "properties": {
-            "default": {
-            "type": "boolean",
-            "title": "checkbox (default)",
-            "description": "This is the checkbox-description"
-            }
-        },
-      additionalProperties: false
-    }
-    const uiSchema = {
-      group1: {
-        'ui:field': 'collapsible'
+  const schema: JSONSchema7 = {
+    "type": "object",
+    "title": "Boolean field",
+    "properties": {
+      "default": {
+        "type": "boolean",
+        "title": "checkbox (default)",
+        "description": "This is the checkbox-description"
       }
-    }
-    return render(schema, uiSchema)
+    },
+    additionalProperties: false
   }
+
+  return render(schema)
+}
 
 

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -3,6 +3,7 @@ import { Theme } from '@rjsf/bootstrap-4'
 import { CollapsibleField } from './CollapsibleField'
 import { TableField } from './table/TableField'
 import { IvresseCheckboxWidget } from './IvresseCheckboxWidget'
+import { IvresseDescriptionField } from './IvresseDescriptionField'
 
 // TODO workaround for broken bootsrap-4 file widget, see https://github.com/rjsf-team/react-jsonschema-form/issues/2095
 const registry = utils.getDefaultRegistry()
@@ -23,6 +24,7 @@ const DefaultFileWidget = registry.widgets.FileWidget;
 if (Theme.fields !== undefined) {
   Theme.fields.collapsible = CollapsibleField
   Theme.fields.table = TableField
+  Theme.fields.DescriptionField = IvresseDescriptionField
 }
 
 export const Form = withTheme(Theme)

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -2,6 +2,7 @@ import { withTheme, utils, WidgetProps } from '@rjsf/core'
 import { Theme } from '@rjsf/bootstrap-4'
 import { CollapsibleField } from './CollapsibleField'
 import { TableField } from './table/TableField'
+import { IvresseCheckboxWidget } from './IvresseCheckboxWidget'
 
 // TODO workaround for broken bootsrap-4 file widget, see https://github.com/rjsf-team/react-jsonschema-form/issues/2095
 const registry = utils.getDefaultRegistry()
@@ -17,6 +18,7 @@ const DefaultFileWidget = registry.widgets.FileWidget;
     </div>
   )
 }
+(Theme as any).widgets.CheckboxWidget = IvresseCheckboxWidget
 
 if (Theme.fields !== undefined) {
   Theme.fields.collapsible = CollapsibleField

--- a/src/IvresseCheckboxWidget.stories.tsx
+++ b/src/IvresseCheckboxWidget.stories.tsx
@@ -2,28 +2,29 @@ import { ComponentMeta, ComponentStory } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { Form } from './Form'
 import { JSONSchema7 } from 'json-schema'
-import { Widgets } from '@rjsf/bootstrap-4/'
+import { IvresseCheckboxWidget } from './IvresseCheckboxWidget'
 
 
-const meta: ComponentMeta<typeof Widgets.CheckboxWidget> = {
+const meta: ComponentMeta<typeof IvresseCheckboxWidget> = {
   title: 'Checkbox',
-  component: Widgets.CheckboxWidget
+  component: IvresseCheckboxWidget
 }
 
 export default meta
 
 function render(schema: JSONSchema7): JSX.Element {
-  debugger
+  const customWidgets = {CheckboxWidget: IvresseCheckboxWidget};
   return (
     <Form
       schema={schema}
       onSubmit={action('onSubmit')}
+      widgets={customWidgets}
     />
   )
 }
 
 
-export const CheckboxWidget: ComponentStory<typeof Form> = () => {
+export const CheckboxWidgetDescription: ComponentStory<typeof Form> = () => {
   const schema: JSONSchema7 = {
     "type": "object",
     "title": "Boolean field",

--- a/src/IvresseCheckboxWidget.stories.tsx
+++ b/src/IvresseCheckboxWidget.stories.tsx
@@ -5,7 +5,6 @@ import { JSONSchema7 } from 'json-schema'
 import { IvresseCheckboxWidget } from './IvresseCheckboxWidget'
 import { IvresseDescriptionField } from './IvresseDescriptionField'
 
-
 const meta: ComponentMeta<typeof IvresseCheckboxWidget> = {
   title: 'Checkbox',
   component: IvresseCheckboxWidget
@@ -13,9 +12,9 @@ const meta: ComponentMeta<typeof IvresseCheckboxWidget> = {
 
 export default meta
 
-function render(schema: JSONSchema7): JSX.Element {
-  const customWidgets = {CheckboxWidget: IvresseCheckboxWidget};
-  const customFields = {DescriptionField: IvresseDescriptionField};
+function render (schema: JSONSchema7): JSX.Element {
+  const customWidgets = { CheckboxWidget: IvresseCheckboxWidget }
+  const customFields = { DescriptionField: IvresseDescriptionField }
   return (
     <Form
       schema={schema}
@@ -26,16 +25,15 @@ function render(schema: JSONSchema7): JSX.Element {
   )
 }
 
-
 export const CheckboxWidgetDescription: ComponentStory<typeof Form> = () => {
   const schema: JSONSchema7 = {
-    "type": "object",
-    "title": "Boolean field",
-    "properties": {
-      "default": {
-        "type": "boolean",
-        "title": "checkbox (default)",
-        "description": "This is the checkbox-description"
+    type: 'object',
+    title: 'Boolean field',
+    properties: {
+      default: {
+        type: 'boolean',
+        title: 'checkbox (default)',
+        description: 'This is the checkbox-description'
       }
     },
     additionalProperties: false
@@ -43,5 +41,3 @@ export const CheckboxWidgetDescription: ComponentStory<typeof Form> = () => {
 
   return render(schema)
 }
-
-

--- a/src/IvresseCheckboxWidget.stories.tsx
+++ b/src/IvresseCheckboxWidget.stories.tsx
@@ -3,6 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { Form } from './Form'
 import { JSONSchema7 } from 'json-schema'
 import { IvresseCheckboxWidget } from './IvresseCheckboxWidget'
+import { IvresseDescriptionField } from './IvresseDescriptionField'
 
 
 const meta: ComponentMeta<typeof IvresseCheckboxWidget> = {
@@ -14,11 +15,13 @@ export default meta
 
 function render(schema: JSONSchema7): JSX.Element {
   const customWidgets = {CheckboxWidget: IvresseCheckboxWidget};
+  const customFields = {DescriptionField: IvresseDescriptionField};
   return (
     <Form
       schema={schema}
       onSubmit={action('onSubmit')}
       widgets={customWidgets}
+      fields={customFields}
     />
   )
 }

--- a/src/IvresseCheckboxWidget.tsx
+++ b/src/IvresseCheckboxWidget.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import { WidgetProps } from "@rjsf/core";
+import Form from "react-bootstrap/Form";
+
+export const IvresseCheckboxWidget = (props: WidgetProps) => {
+    const {
+        id,
+        value,
+        required,
+        disabled,
+        readonly,
+        label,
+        schema,
+        autofocus,
+        onChange,
+        onBlur,
+        onFocus,
+        DescriptionField,
+    } = props;
+
+    const _onChange = ({
+        target: { checked },
+    }: React.FocusEvent<HTMLInputElement>) => onChange(checked);
+    const _onBlur = ({
+        target: { checked },
+    }: React.FocusEvent<HTMLInputElement>) => onBlur(id, checked);
+    const _onFocus = ({
+        target: { checked },
+    }: React.FocusEvent<HTMLInputElement>) => onFocus(id, checked);
+
+    const desc = label || schema.description;
+    return (
+        <Form.Group className={`checkbox ${disabled || readonly ? "disabled" : ""}`}>
+            <Form.Check
+                id={id}
+                label={desc}
+                checked={typeof value === "undefined" ? false : value}
+                required={required}
+                disabled={disabled || readonly}
+                autoFocus={autofocus}
+                onChange={_onChange}
+                type="checkbox"
+                onBlur={_onBlur}
+                onFocus={_onFocus}
+            />
+            {schema.description && (
+                <DescriptionField description={schema.description} />
+            )}
+        </Form.Group>
+    );
+};

--- a/src/IvresseCheckboxWidget.tsx
+++ b/src/IvresseCheckboxWidget.tsx
@@ -1,52 +1,58 @@
-import React from "react";
+// Customized from: https://github.com/rjsf-team/react-jsonschema-form/blob/724fb0bc3f1ae5d1d9b761b2bff7cf5c64fd7459/packages/bootstrap-4/src/CheckboxWidget/CheckboxWidget.tsx#L3-L48
 
-import { WidgetProps } from "@rjsf/core";
-import Form from "react-bootstrap/Form";
+import React from 'react'
 
-export const IvresseCheckboxWidget = (props: WidgetProps) => {
-    const {
-        id,
-        value,
-        required,
-        disabled,
-        readonly,
-        label,
-        schema,
-        autofocus,
-        onChange,
-        onBlur,
-        onFocus,
-        DescriptionField,
-    } = props;
+import { WidgetProps } from '@rjsf/core'
+import Form from 'react-bootstrap/Form'
 
-    const _onChange = ({
-        target: { checked },
-    }: React.FocusEvent<HTMLInputElement>) => onChange(checked);
-    const _onBlur = ({
-        target: { checked },
-    }: React.FocusEvent<HTMLInputElement>) => onBlur(id, checked);
-    const _onFocus = ({
-        target: { checked },
-    }: React.FocusEvent<HTMLInputElement>) => onFocus(id, checked);
+export const IvresseCheckboxWidget = (props: WidgetProps): JSX.Element => {
+  const {
+    id,
+    value,
+    required,
+    disabled,
+    readonly,
+    label,
+    schema,
+    autofocus,
+    onChange,
+    onBlur,
+    onFocus,
+    DescriptionField
+  } = props
 
-    const desc = label || schema.description;
-    return (
-        <Form.Group className={`checkbox ${disabled || readonly ? "disabled" : ""}`}>
-            <Form.Check
-                id={id}
-                label={desc}
-                checked={typeof value === "undefined" ? false : value}
-                required={required}
-                disabled={disabled || readonly}
-                autoFocus={autofocus}
-                onChange={_onChange}
-                type="checkbox"
-                onBlur={_onBlur}
-                onFocus={_onFocus}
-            />
-            {schema.description && (
-                <DescriptionField description={schema.description} />
-            )}
-        </Form.Group>
-    );
-};
+  const _onChange = ({
+    target: { checked }
+  }: React.FocusEvent<HTMLInputElement>): void => onChange(checked)
+  const _onBlur = ({
+    target: { checked }
+  }: React.FocusEvent<HTMLInputElement>): void => onBlur(id, checked)
+  const _onFocus = ({
+    target: { checked }
+  }: React.FocusEvent<HTMLInputElement>): void => onFocus(id, checked)
+
+  const desc = label !== '' ? label : schema.description
+  let descfield = <></>
+  if (schema.description !== undefined || schema.description !== '') {
+    descfield = <DescriptionField description={schema.description} />
+  }
+
+  return (
+    <Form.Group className={`checkbox ${disabled || readonly ? 'disabled' : ''}`}>
+      <Form.Check
+        id={id}
+        label={desc}
+        checked={typeof value === 'undefined' ? false : value}
+        required={required}
+        disabled={disabled || readonly}
+        autoFocus={autofocus}
+        onChange={_onChange}
+        type='checkbox'
+        onBlur={_onBlur}
+        onFocus={_onFocus}
+      />
+      {descfield}
+
+    </Form.Group>
+  )
+}

--- a/src/IvresseDescriptionField.tsx
+++ b/src/IvresseDescriptionField.tsx
@@ -1,14 +1,15 @@
-import { FieldProps } from "@rjsf/core";
+// Customized from: https://github.com/rjsf-team/react-jsonschema-form/blob/724fb0bc3f1ae5d1d9b761b2bff7cf5c64fd7459/packages/bootstrap-4/src/DescriptionField/DescriptionField.tsx#L2-L14
+
+import { FieldProps } from '@rjsf/core'
 
 export interface DescriptionFieldProps extends Partial<FieldProps> {
-  description?: string;
+  description?: string
 }
 
-export const IvresseDescriptionField = ({ description }: Partial<FieldProps>) => {
-  if (description) {
-    return <small><div className="mb-3 text-muted">{description}</div></small>;
+export const IvresseDescriptionField = ({ description }: DescriptionFieldProps): JSX.Element => {
+  if (description !== undefined || description !== '') {
+    return <small><div className='mb-3 text-muted'>{description}</div></small>
   }
 
-  return null;
-};
-
+  return <></>
+}

--- a/src/IvresseDescriptionField.tsx
+++ b/src/IvresseDescriptionField.tsx
@@ -1,0 +1,14 @@
+import { FieldProps } from "@rjsf/core";
+
+export interface DescriptionFieldProps extends Partial<FieldProps> {
+  description?: string;
+}
+
+export const IvresseDescriptionField = ({ description }: Partial<FieldProps>) => {
+  if (description) {
+    return <small><div className="mb-3 text-muted">{description}</div></small>;
+  }
+
+  return null;
+};
+


### PR DESCRIPTION
See #61.

The current PR adds a storybook for the checkbox widget and shows the description with the checkbox field, with formatting that matches other description fields (e.g. for select and radio widgets).