### PR TITLE
Make topoaa.mol parameter molecule aware

### DIFF
--- a/integration-tests/molecules.spec.ts
+++ b/integration-tests/molecules.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { expect, test } from '@playwright/test'
 import { readFile } from 'fs/promises'
 
 test.describe('given 1 molecule and a flexref node with seg parameter defined', () => {
@@ -145,4 +145,30 @@ test.describe('given 2 molecules and a flexref node with seg parameter defined f
       await page.pause()
     })
   })
+})
+
+
+test.describe('Given expert catalog and example loaded', () => {
+  test.beforeEach(async ({ page }) => {
+    // Go to http://localhost:3000/
+    await page.goto('http://localhost:3000/');
+    // Select http://localhost:3000/catalog/haddock3.expert.yaml
+    await page.locator('select').selectOption('http://localhost:3000/catalog/haddock3.expert.yaml');
+    // Click text=docking-protein-ligand
+    await page.locator('text=docking-protein-ligand').click();
+  })
+  test('The topoaa, input molecules should be expandable', async ({ page }) => {
+    // Click ol button:has-text("topoaa")
+    await page.locator('ol button:has-text("topoaa")').click();
+
+    await page.pause() // wait before clicking on bad button
+
+    // Click #expander4input_molecules svg
+    await page.locator('#expander4input_molecules svg').click();
+
+    const error = page.locator('text=Something went terribly wrong.')
+    await expect(error).not.toBeVisible()
+    // Run me with `yarn test:integration --headed -g 'topoaa'`
+  });
+
 })

--- a/integration-tests/molecules.spec.ts
+++ b/integration-tests/molecules.spec.ts
@@ -147,28 +147,26 @@ test.describe('given 2 molecules and a flexref node with seg parameter defined f
   })
 })
 
-
 test.describe('Given expert catalog and example loaded', () => {
   test.beforeEach(async ({ page }) => {
     // Go to http://localhost:3000/
-    await page.goto('http://localhost:3000/');
+    await page.goto('http://localhost:3000/')
     // Select http://localhost:3000/catalog/haddock3.expert.yaml
-    await page.locator('select').selectOption('http://localhost:3000/catalog/haddock3.expert.yaml');
+    await page.locator('select').selectOption('http://localhost:3000/catalog/haddock3.expert.yaml')
     // Click text=docking-protein-ligand
-    await page.locator('text=docking-protein-ligand').click();
+    await page.locator('text=docking-protein-ligand').click()
   })
   test('The topoaa, input molecules should be expandable', async ({ page }) => {
     // Click ol button:has-text("topoaa")
-    await page.locator('ol button:has-text("topoaa")').click();
+    await page.locator('ol button:has-text("topoaa")').click()
 
     await page.pause() // wait before clicking on bad button
 
     // Click #expander4input_molecules svg
-    await page.locator('#expander4input_molecules svg').click();
+    await page.locator('#expander4input_molecules svg').click()
 
     const error = page.locator('text=Something went terribly wrong.')
     await expect(error).not.toBeVisible()
     // Run me with `yarn test:integration --headed -g 'topoaa'`
-  });
-
+  })
 })

--- a/public/catalog/haddock3.easy.yaml
+++ b/public/catalog/haddock3.easy.yaml
@@ -427,7 +427,6 @@ nodes:
         type: boolean
       mol:
         title: Input molecule configuration
-        description: Specific molecule configuration
         $comment: You can expand this parameter and associated sub-parameters to the
           other input molecules. For example, if you input three molecules, you can
           define mol1, mol2, and mol3 subparameters. Those not defined will be populated

--- a/public/catalog/haddock3.easy.yaml
+++ b/public/catalog/haddock3.easy.yaml
@@ -501,6 +501,7 @@ nodes:
                 format: residue
           required: []
           additionalProperties: false
+        maxItemsFrom: molecules
     required: []
     additionalProperties: false
   uiSchema:

--- a/public/catalog/haddock3.expert.yaml
+++ b/public/catalog/haddock3.expert.yaml
@@ -2188,6 +2188,7 @@ nodes:
                 format: residue
           required: []
           additionalProperties: false
+        maxItemsFrom: molecules
     required: []
     additionalProperties: false
   uiSchema:

--- a/public/catalog/haddock3.expert.yaml
+++ b/public/catalog/haddock3.expert.yaml
@@ -2114,7 +2114,6 @@ nodes:
         minimum: 0
       mol:
         title: Input molecule configuration
-        description: Specific molecule configuration
         $comment: You can expand this parameter and associated sub-parameters to the
           other input molecules. For example, if you input three molecules, you can
           define mol1, mol2, and mol3 subparameters. Those not defined will be populated

--- a/public/catalog/haddock3.guru.yaml
+++ b/public/catalog/haddock3.guru.yaml
@@ -2325,6 +2325,7 @@ nodes:
                 format: residue
           required: []
           additionalProperties: false
+        maxItemsFrom: molecules
     required: []
     additionalProperties: false
   uiSchema:

--- a/public/catalog/haddock3.guru.yaml
+++ b/public/catalog/haddock3.guru.yaml
@@ -2251,7 +2251,6 @@ nodes:
         minimum: 0
       mol:
         title: Input molecule configuration
-        description: Specific molecule configuration
         $comment: You can expand this parameter and associated sub-parameters to the
           other input molecules. For example, if you input three molecules, you can
           define mol1, mol2, and mol3 subparameters. Those not defined will be populated

--- a/util/generate_haddock3_catalog.py
+++ b/util/generate_haddock3_catalog.py
@@ -181,6 +181,7 @@ def config2schema(config):
             prop.update({
                 'type': 'array',
                 'items': schemas['schema'],
+                'maxItemsFrom': 'molecules',
             })
 
             if schemas['uiSchema']:

--- a/util/generate_haddock3_catalog.py
+++ b/util/generate_haddock3_catalog.py
@@ -183,6 +183,8 @@ def config2schema(config):
                 'items': schemas['schema'],
                 'maxItemsFrom': 'molecules',
             })
+            # TODO rjsf gives error when description is present, so for now remove it
+            del prop['description']
 
             if schemas['uiSchema']:
                 prop_ui['items'] = schemas['uiSchema']


### PR DESCRIPTION
The topoaa.mol parameter is not enhanced when molecules have been uploaded. It would be nice if 2 molecules where uploaded the mol parameter would show 2 sub forms. Also nested hisd, hise parameters could pick from the residue numbers of the molecules.

To test:
1. Load example
2. Select topoaa
3. Expand `input molecules`
4. There should be 2 sub forms
5. The choices when adding hisd or hise for second molecule should be just 500

Includes a integration test (`yarn test:integration --headed -g 'topoaa'`) that works because of workaround for #81 .