### PR TITLE
Switch to PrismLight

### DIFF
--- a/src/HighlightedCode.tsx
+++ b/src/HighlightedCode.tsx
@@ -1,4 +1,4 @@
-import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter'
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
 import toml from 'react-syntax-highlighter/dist/esm/languages/prism/toml'
 import style from 'react-syntax-highlighter/dist/esm/styles/prism/vs'
 


### PR DESCRIPTION
The https://github.com/react-syntax-highlighter/react-syntax-highlighter can be used in different ways. In this PR I use a way that when I do `yarn build;yarn serve` renders the text correctly. The [docs](https://github.com/react-syntax-highlighter/react-syntax-highlighter) say that this way produces a bigger bundle, but I have not verified.

Refs #74

To test:

1. checkout branch `yarn build; yarn serve`
2. Open app 
3. Load example in lower left corner
4. Switch to text mode in middle column
5. Expect to see highlighted code, while before in some browser you would see `[object Object]`

Also test `yarn dev` and https://deploy-preview-90--wonderful-noether-53a9e8.netlify.app/ with various browsers.