### PR TITLE
Make catalog categories collapsible

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The catalog is a YAML formatted file which tells the app what nodes are availabl
 3. catagories: Descriptions of node categories
     * name: Name of category
     * description: Description of category
+    * collapsed (optional): Whether category should be rendered collapsed initially
 4. examples: Title and link to example workflows
     * map with title as key and link as value
 5. title: Title of the catalog

--- a/apps/kitchensink/src/kitchensink.json
+++ b/apps/kitchensink/src/kitchensink.json
@@ -58,6 +58,11 @@
         {
             "name": "moleculetest",
             "description": "Nodes with molecules aware parameters"
+        },
+        {
+            "name": "collapsedcat",
+            "description": "Category which is initially collapsed",
+            "collapsed": true
         }
     ],
     "nodes": [
@@ -721,6 +726,22 @@
                     }
                 }
             }
+        },
+        {
+            "id": "node12",
+            "label": "Node in initially collapsed cat",
+            "description": "Description 12",
+            "category": "collapsedcat",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "prop1": {
+                        "type": "string"
+                    }
+                }
+            },
+            "uiSchema": {},
+            "tomlSchema": {}
         }
     ]
 }

--- a/packages/core/src/CatalogCategory.tsx
+++ b/packages/core/src/CatalogCategory.tsx
@@ -1,16 +1,34 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useCatalog } from './store'
 import { ICategory } from './types'
 import { CatalogNode } from './CatalogNode'
 
-export const CatalogCategory = ({ name, description }: ICategory): JSX.Element => {
+export const CatalogCategory = ({ name, description, collapsed: initiallyCollapsed }: ICategory): JSX.Element => {
+  const [collapsed, setCollapsed] = useState(initiallyCollapsed ?? false)
   const catalog = useCatalog()
+  const style = {
+    // TODO On https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type
+    // disclosure-open/closed are said to be experimental, find how much compatibility there is.
+    listStyleType: collapsed ? 'disclosure-closed' : 'disclosure-open',
+    // utf failed in chrome
+    // listStyleType: collapsed ? '⏷' : '⏵'
+  }
   return (
-    <li>
+    <li
+      style={style} onClick={(e) => {
+        if (e.target === e.currentTarget) {
+          // only toggle when list marker is clicked
+          return setCollapsed((c) => !c)
+        }
+      }}
+    >
       <span title={description}>{name}</span>
-      <ul>
-        {catalog?.nodes.filter((node) => node.category === name).map((node) => <CatalogNode key={node.id} {...node} />)}
-      </ul>
+      {
+      !collapsed &&
+        <ul>
+          {catalog?.nodes.filter((node) => node.category === name).map((node) => <CatalogNode key={node.id} {...node} />)}
+        </ul>
+      }
     </li>
   )
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,6 +30,7 @@ export interface ICatalogNode {
 export interface ICategory {
   name: string
   description: string
+  collapsed?: boolean
 }
 
 export interface IGlobal {


### PR DESCRIPTION
Fixes #99

TODO
* [ ] test browsers
* [ ] make haddock3 extras catagory collapsed initially.

To test 
1. `yarn dev`
2. Open kitchensink app at http://localhost:3002
3. The categories have a triangle in front of them, clicking a triangle should collapse the category and hide the nodes belonging to that category.
4. The `collapsedcat` category should be collapsed initially.