### PR TITLE
WIP: save form data onBlur

### DIFF
--- a/apps/haddock3-download/src/App.css
+++ b/apps/haddock3-download/src/App.css
@@ -10,7 +10,7 @@
   grid-template-areas: "head head head"
                         "catalog workflow node"
                         "catalog workflow-actions node-actions";
-  grid-template-columns: min-content minmax(12rem,1fr) minmax(20rem,2fr);
+  grid-template-columns: min-content minmax(19rem,1fr) minmax(20rem,2fr);
   grid-template-rows: auto 1fr auto;
   column-gap: 1rem;
 }

--- a/apps/haddock3-download/src/App.tsx
+++ b/apps/haddock3-download/src/App.tsx
@@ -29,17 +29,13 @@ function App (): JSX.Element {
         </GridArea>
         <GridArea area='workflow' className='workflow-area'>
           <WorkflowPanel>
+            <WorkflowDownloadButton />
             <WorkflowUploadButton />
+            <WorkflowClear />
           </WorkflowPanel>
         </GridArea>
         <GridArea area='node'>
           <NodePanel />
-        </GridArea>
-        <GridArea className='action-row' area='workflow-actions'>
-          <WorkflowDownloadButton />
-          <WorkflowClear />
-        </GridArea>
-        <GridArea className='action-row' area='node-actions'>
           <FormActions />
         </GridArea>
       </div>

--- a/packages/core/src/FormActions.tsx
+++ b/packages/core/src/FormActions.tsx
@@ -33,13 +33,13 @@ import { useSelectNodeIndex, useActiveSubmitButton, useWorkflow } from './store'
  * toggleGlobalEdit()
  * ```
  */
-export const FormActions = (): JSX.Element => {
+export const FormActions = (): JSX.Element|null => {
   const index = useSelectNodeIndex()
   const { deleteNode, clearNodeSelection } = useWorkflow()
   const submitFormRef = useActiveSubmitButton()
   const { editingGlobal, toggleGlobalEdit } = useWorkflow()
   if (submitFormRef === undefined || !(index > -1 || editingGlobal)) {
-    return <></>
+    return null
   }
   const DeleteButton = (
     <button

--- a/packages/core/src/GlobalForm.tsx
+++ b/packages/core/src/GlobalForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { EmotionJSX } from '@emotion/react/types/jsx-namespace'
 import { Form } from '@i-vresse/wb-form'
 
 import { FormProps } from './FormProps'
@@ -6,21 +7,51 @@ import { useCatalog, useGlobalFormData, useSetActiveSubmitButton } from './store
 
 import '@i-vresse/wb-form/dist/index.css'
 
-export const GlobalForm = ({ fields, widgets }: FormProps): JSX.Element => {
+export const GlobalForm = ({ fields, widgets }: FormProps): EmotionJSX.Element => {
   const { global: globalSchemas } = useCatalog()
   const [formData, setFormData] = useGlobalFormData()
   const submitFormRefSetter = useSetActiveSubmitButton()
   const uiSchema = globalSchemas.formUiSchema
+  let localErrors: any[] = []; let localData: any; let toSave: boolean = false
+
+  function onSectionBlur (e: any): void {
+    console.group('GlobalForm.onSectionBlur')
+    console.log('formData...', localData)
+    console.log('localErrors...', localErrors)
+    console.log('toSave...', toSave)
+    console.log('e...', e)
+    console.groupEnd()
+    // do not bubble events
+    e.stopPropagation()
+    if (localErrors?.length === 0 && toSave) {
+      // debugger
+      setFormData(localData)
+    }
+  }
+
   return (
-    <Form
-      schema={globalSchemas.formSchema ?? {}}
-      uiSchema={uiSchema}
-      formData={formData}
-      onSubmit={({ formData }) => setFormData(formData)}
-      fields={fields}
-      widgets={widgets}
-    >
-      <button ref={submitFormRefSetter} style={{ display: 'none' }} />
-    </Form>
+    <section onBlur={onSectionBlur}>
+      <Form
+        schema={globalSchemas.formSchema ?? {}}
+        uiSchema={uiSchema}
+        formData={formData}
+        onSubmit={({ formData }) => {
+          setFormData(formData)
+        }}
+        liveValidate
+        showErrorList={false}
+        onChange={(props) => {
+          const { errors, formData } = props
+          localErrors = errors
+          localData = formData
+          // set save flag if localData is not empty
+          toSave = Object.keys(localData).length > 0
+        }}
+        fields={fields}
+        widgets={widgets}
+      >
+        <button ref={submitFormRefSetter} style={{ display: 'none' }} />
+      </Form>
+    </section>
   )
 }

--- a/packages/core/src/NodeForm.tsx
+++ b/packages/core/src/NodeForm.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { EmotionJSX } from '@emotion/react/types/jsx-namespace'
 import { Form } from '@i-vresse/wb-form'
 
 import { FormProps } from './FormProps'
@@ -6,13 +7,17 @@ import { useSelectedCatalogNode, useSelectedNode, useSelectedNodeFormData, useSe
 
 import '@i-vresse/wb-form/dist/index.css'
 
-export const NodeForm = ({ fields, widgets }: FormProps): JSX.Element => {
+export const NodeForm = ({ fields, widgets }: FormProps): EmotionJSX.Element => {
   const [formData, setFormData] = useSelectedNodeFormData()
   const node = useSelectedNode()
   const catalogNode = useSelectedCatalogNode()
   const schema = useSelectedNodeFormSchema() ?? {}
   const submitFormRefSetter = useSetActiveSubmitButton()
   const uiSchema = useSelectedNodeFormUiSchema() ?? {}
+  let localErrors: any[] = []
+  let localData: any
+  let toSave: boolean = false
+
   if (node === undefined) {
     return <div>No node selected</div>
   }
@@ -20,8 +25,23 @@ export const NodeForm = ({ fields, widgets }: FormProps): JSX.Element => {
     return <div>Unable to find schema belonging to node</div>
   }
 
+  function onSectionBlur (e: any): void {
+    console.group('NodeForm.onSectionBlur')
+    console.log('formData...', localData)
+    console.log('localErrors...', localErrors)
+    console.log('toSave...', toSave)
+    console.log('e...', e)
+    console.groupEnd()
+    // do not bubble events
+    e.stopPropagation()
+    if (localErrors?.length === 0 && toSave) {
+      // debugger
+      setFormData(localData)
+    }
+  }
+
   return (
-    <>
+    <section onBlur={onSectionBlur}>
       <h4>{catalogNode.label} ({node.type})</h4>
       <div style={{ marginBottom: '20px' }}>
         {catalogNode.description}
@@ -30,12 +50,23 @@ export const NodeForm = ({ fields, widgets }: FormProps): JSX.Element => {
         schema={schema}
         uiSchema={uiSchema}
         formData={formData}
-        onSubmit={({ formData }) => setFormData(formData)}
+        onSubmit={({ formData }) => {
+          setFormData(formData)
+        }}
+        liveValidate
+        showErrorList={false}
+        onChange={(props) => {
+          const { errors, formData } = props
+          localErrors = errors
+          localData = formData
+          // set save flag if localData is not empty
+          toSave = Object.keys(localData).length > 0
+        }}
         fields={fields}
         widgets={widgets}
       >
         <button ref={submitFormRefSetter} style={{ display: 'none' }} />
       </Form>
-    </>
+    </section>
   )
 }

--- a/packages/core/src/NodePanel.tsx
+++ b/packages/core/src/NodePanel.tsx
@@ -14,6 +14,16 @@ export const NodePanel = ({ fields, widgets }: FormProps): JSX.Element => {
   const { editingGlobal } = useWorkflow()
   let form = <div>No node or global parameters selected for configuration.</div>
   let legend = 'Node'
+
+  function onSectionBlur (): void {
+    console.group('NodePanel.onSectionBlur')
+    console.log('form...', form)
+    console.groupEnd()
+    // if (localErrors?.length === 0 && toSave) {
+    //   setFormData(localData)
+    // }
+  }
+
   if (editingGlobal) {
     form = (
       <GlobalForm
@@ -32,7 +42,7 @@ export const NodePanel = ({ fields, widgets }: FormProps): JSX.Element => {
     )
   }
   return (
-    <fieldset>
+    <fieldset onBlur={onSectionBlur}>
       <legend>{legend}</legend>
       {form}
     </fieldset>

--- a/packages/core/src/VisualPanel.tsx
+++ b/packages/core/src/VisualPanel.tsx
@@ -15,7 +15,7 @@ import { VisualNode } from './VisualNode'
 import { GripVertical } from './GripVertical'
 
 export const VisualPanel = (): JSX.Element => {
-  const { nodes } = useWorkflow()
+  const { nodes, toggleGlobalEdit } = useWorkflow()
   const draggingCatalogNode = useDraggingCatalogNodeState()[0]
   const draggingWorkflowNodeCode = useDraggingWorkflowNodeState()[0]
   const draggingWorkflowNode = nodes.find(
@@ -57,12 +57,21 @@ export const VisualPanel = (): JSX.Element => {
   const { setNodeRef } = useDroppable({ id: 'catalog-dropzone' })
   return (
     <div
-      ref={setNodeRef} style={{
+      ref={setNodeRef}
+      style={{
         flex: 1,
         display: 'flex',
-        flexDirection: 'column'
+        flexDirection: 'column',
+        padding: '0.5rem 0rem'
       }}
     >
+      <button
+        className='btn btn-light btn-sm btn-block btn-visual-node'
+        onClick={toggleGlobalEdit}
+        title='Edit global parameters'
+      >
+        0. Global parameters
+      </button>
       <SortableContext
         items={sortableItems}
         strategy={verticalListSortingStrategy}

--- a/packages/core/src/WorkflowDownloadButton.tsx
+++ b/packages/core/src/WorkflowDownloadButton.tsx
@@ -22,6 +22,6 @@ export const WorkflowDownloadButton = (): JSX.Element => {
   }
 
   return (
-    <button className='btn btn-primary' onClick={downloadWorkflow}>Download archive</button>
+    <button className='btn btn-primary' onClick={downloadWorkflow}>Download</button>
   )
 }

--- a/packages/core/src/WorkflowPanel.tsx
+++ b/packages/core/src/WorkflowPanel.tsx
@@ -1,7 +1,6 @@
 import React, { PropsWithChildren, useState } from 'react'
 import { TextPanel } from './TextPanel'
 import { VisualPanel } from './VisualPanel'
-import { useWorkflow } from './store'
 
 type ITab = 'text' | 'visual'
 
@@ -12,7 +11,6 @@ type ITab = 'text' | 'visual'
  */
 export const WorkflowPanel = ({ children }: PropsWithChildren<{}>): JSX.Element => {
   const [tab, setTab] = useState<ITab>('visual')
-  const { toggleGlobalEdit } = useWorkflow()
 
   const selectedPanel = tab === 'visual' ? <VisualPanel /> : <TextPanel />
   const visualTabStyle = tab === 'visual' ? 'nav-link active' : 'nav-link'
@@ -27,7 +25,6 @@ export const WorkflowPanel = ({ children }: PropsWithChildren<{}>): JSX.Element 
     >
       <legend>Workflow</legend>
       <div className='btn-toolbar'>
-        <button className='btn btn-light' onClick={toggleGlobalEdit} title='Edit global parameters'>Global parameters</button>
         {children}
       </div>
       <ul className='nav nav-tabs'>

--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -503,7 +503,7 @@ export function useWorkflow (): UseWorkflow {
     editingGlobal,
     global,
     toggleGlobalEdit () {
-      setEditingGlobal(!editingGlobal)
+      setEditingGlobal(true)
       setSelectedNodeIndex(-1)
     },
     addNodeToWorkflowAt (nodeType: string, targetId: string) {


### PR DESCRIPTION
## Save all form changes automatically when valid

The data is saved each time the focus on the form element is lost and the data is valid (the form validation has no errors). The form validation during editing the form is therefore enabled. 

Some input components, file input for example, have no 'blur' event. However setting on blur event on the form parent element seem to solve the problem and generate blur/lost focus event.

The form buttons, Save, Cancel and Delete are not removed in this version.

This approach should be extensively tested in order to ensure that it does not cause any errors due to premature saving of data.


 