### PR TITLE
Remove css-in-js button styles from core

### DIFF
--- a/apps/haddock3-download/src/App.css
+++ b/apps/haddock3-download/src/App.css
@@ -39,6 +39,18 @@
   gap: 0.5rem;
 }
 
+/* remove gap from dropdown group */
+.dropdown.btn-group {
+  gap: 0rem;
+}
+
+/* center + icon in the button */
+.array-item-add{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .no-wrap{
   text-wrap: nowrap;
 }

--- a/apps/haddock3-download/src/App.css
+++ b/apps/haddock3-download/src/App.css
@@ -23,6 +23,7 @@
   gap: 1rem;
 }
 
+.btn-visual-panel,
 .btn-catalog-node {
   width: 100%;
 }
@@ -48,7 +49,8 @@ li > ul{
   padding: 0rem;
 }
 
-div[role="button"]{
+div[role="button"],
+.btn-catalog-node{
   margin: 0.5rem 0rem;
   cursor: pointer;
 }
@@ -73,7 +75,6 @@ div[role="button"]{
   padding: 1rem 0rem;
 }
 
-
 /* Show panel section is clickable */
 h5[id^="expander4"]{
   cursor: pointer;
@@ -81,4 +82,21 @@ h5[id^="expander4"]{
 /* Allow scrollbars in the card when content is too large */
 .card-body{
   overflow: auto;
+}
+
+/* Alow scrollbars on tables which exceed card width */
+.form-group > fieldset {
+  overflow: auto;
+}
+
+/* hide commands by default */
+.btn-catalog-node .grip,
+.btn-visual-node .btn-group{
+  visibility: hidden;
+}
+
+/* show commands on hover */
+.btn-catalog-node:hover .grip,
+.btn-visual-node:hover .btn-group {
+  visibility: visible;
 }

--- a/apps/haddock3-download/src/App.css
+++ b/apps/haddock3-download/src/App.css
@@ -15,6 +15,12 @@
   column-gap: 1rem;
 }
 
+/* Style workflow area section */
+.workflow-area {
+  display: flex;
+  flex-direction: column;
+}
+
 /* Style various form buttons */
 .btn {
   display: flex;

--- a/apps/haddock3-download/src/App.css
+++ b/apps/haddock3-download/src/App.css
@@ -1,20 +1,84 @@
+/*
+  Customise workflow builder components
+*/
+
 .page {
-    padding: 1em;
-    display: grid;
-    width: 100%;
-    height: 100vh;
-    grid-template-areas: "head head head"
-                         "catalog workflow node"
-                         "catalog workflow-actions node-actions";
-    grid-template-columns: 1fr 1fr 2fr;
-    grid-template-rows: auto 1fr auto;
-    column-gap: 0.5rem;
+  padding: 1em;
+  display: grid;
+  width: 100%;
+  height: 100vh;
+  grid-template-areas: "head head head"
+                        "catalog workflow node"
+                        "catalog workflow-actions node-actions";
+  grid-template-columns: min-content minmax(12rem,1fr) minmax(20rem,2fr);
+  grid-template-rows: auto 1fr auto;
+  column-gap: 1rem;
 }
 
-.page > div {
-    overflow: auto;
+/* Style various form buttons */
+.btn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
 }
 
-.action-row {
-    padding: 0.25rem
+.btn-catalog-node {
+  width: 100%;
+}
+
+.btn-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.no-wrap{
+  text-wrap: nowrap;
+}
+
+ul{
+  padding: 0.25rem 0.25rem 0.25rem 1.25rem;
+}
+
+li{
+  list-style-type: none;
+}
+
+li > ul{
+  padding: 0rem;
+}
+
+div[role="button"]{
+  margin: 0.5rem 0rem;
+  cursor: pointer;
+}
+
+/* Format actions section at the bottom */
+.action-row,
+.action-row>.nav {
+  display: flex;
+  gap: 1rem;
+  padding: 0.25rem;
+}
+
+.action-row>.nav {
+  flex: 1;
+  justify-content: flex-end;
+}
+
+
+.btn-toolbar{
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 0rem;
+}
+
+
+/* Show panel section is clickable */
+h5[id^="expander4"]{
+  cursor: pointer;
+}
+/* Allow scrollbars in the card when content is too large */
+.card-body{
+  overflow: auto;
 }

--- a/apps/haddock3-download/src/App.tsx
+++ b/apps/haddock3-download/src/App.tsx
@@ -27,12 +27,7 @@ function App (): JSX.Element {
             <CatalogPicker />
           </CatalogPanel>
         </GridArea>
-        <GridArea
-          area='workflow' style={{
-            display: 'flex',
-            flexDirection: 'column'
-          }}
-        >
+        <GridArea area='workflow' className='workflow-area'>
           <WorkflowPanel>
             <WorkflowUploadButton />
           </WorkflowPanel>

--- a/apps/haddock3-download/src/App.tsx
+++ b/apps/haddock3-download/src/App.tsx
@@ -27,7 +27,12 @@ function App (): JSX.Element {
             <CatalogPicker />
           </CatalogPanel>
         </GridArea>
-        <GridArea area='workflow'>
+        <GridArea
+          area='workflow' style={{
+            display: 'flex',
+            flexDirection: 'column'
+          }}
+        >
           <WorkflowPanel>
             <WorkflowUploadButton />
           </WorkflowPanel>

--- a/apps/haddock3-download/src/App.tsx
+++ b/apps/haddock3-download/src/App.tsx
@@ -11,8 +11,8 @@ import {
   WorkflowUploadButton,
   Wrapper
 } from '@i-vresse/wb-core'
+
 import '@i-vresse/wb-form/dist/index.css'
-import 'bootstrap/dist/css/bootstrap.min.css'
 import './App.css'
 
 function App (): JSX.Element {

--- a/apps/haddock3-download/src/index.css
+++ b/apps/haddock3-download/src/index.css
@@ -8,6 +8,5 @@ body {
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/apps/haddock3-download/src/main.tsx
+++ b/apps/haddock3-download/src/main.tsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
+
+import 'bootstrap/dist/css/bootstrap.min.css'
 import './index.css'
 import App from './App'
 

--- a/apps/haddock3-galaxy/src/App.css
+++ b/apps/haddock3-galaxy/src/App.css
@@ -1,21 +1,110 @@
+/*
+  Customise workflow builder components
+  NOTE! copy of apps/haddock3-download/src/App.css
+*/
+
 .page {
     padding: 1em;
     display: grid;
     width: 100%;
     height: 100vh;
     grid-template-areas: "head head head"
-                         "catalog workflow node"
-                         "catalog workflow-actions node-actions";
-    grid-template-columns: 1fr 1fr 2fr;
+        "catalog workflow node"
+        "catalog workflow-actions node-actions";
+    grid-template-columns: min-content minmax(12rem, 1fr) minmax(20rem, 2fr);
     grid-template-rows: auto 1fr auto;
-    column-gap: 0.5rem;
+    column-gap: 1rem;
 }
 
-.page > div {
+/* Style workflow area section */
+.workflow-area {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Style various form buttons */
+.btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.btn-visual-panel,
+.btn-catalog-node {
+    width: 100%;
+}
+
+.btn-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.no-wrap {
+    text-wrap: nowrap;
+}
+
+ul {
+    padding: 0.25rem 0.25rem 0.25rem 1.25rem;
+}
+
+li {
+    list-style-type: none;
+}
+
+li>ul {
+    padding: 0rem;
+}
+
+div[role="button"],
+.btn-catalog-node {
+    margin: 0.5rem 0rem;
+    cursor: pointer;
+}
+
+/* Format actions section at the bottom */
+.action-row,
+.action-row>.nav {
+    display: flex;
+    gap: 1rem;
+    padding: 0.25rem;
+}
+
+.action-row>.nav {
+    flex: 1;
+    justify-content: flex-end;
+}
+
+
+.btn-toolbar {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 0rem;
+}
+
+/* Show panel section is clickable */
+h5[id^="expander4"] {
+    cursor: pointer;
+}
+
+/* Allow scrollbars in the card when content is too large */
+.card-body {
     overflow: auto;
 }
 
-.page > .action-row {
-    padding: 0.25rem;
-    overflow: unset;
+/* Alow scrollbars on tables which exceed card width */
+.form-group>fieldset {
+    overflow: auto;
+}
+
+/* hide commands by default */
+.btn-catalog-node .grip,
+.btn-visual-node .btn-group {
+    visibility: hidden;
+}
+
+/* show commands on hover */
+.btn-catalog-node:hover .grip,
+.btn-visual-node:hover .btn-group {
+    visibility: visible;
 }

--- a/apps/haddock3-galaxy/src/App.css
+++ b/apps/haddock3-galaxy/src/App.css
@@ -40,6 +40,18 @@
     gap: 0.5rem;
 }
 
+/* remove gap from dropdown group */
+.dropdown.btn-group {
+    gap: 0rem;
+}
+
+/* center + icon in the button */
+.array-item-add {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .no-wrap {
     text-wrap: nowrap;
 }

--- a/apps/haddock3-galaxy/src/App.tsx
+++ b/apps/haddock3-galaxy/src/App.tsx
@@ -62,7 +62,7 @@ function App (): JSX.Element {
           <CatalogPicker catalogIndexURL={catalogIndexURL} />
         </CatalogPanel>
       </GridArea>
-      <GridArea area='workflow'>
+      <GridArea area='workflow' className='workflow-area'>
         <WorkflowPanel>
           <WorkflowUploadButton />
         </WorkflowPanel>

--- a/apps/haddock3-submit/src/App.css
+++ b/apps/haddock3-submit/src/App.css
@@ -40,6 +40,18 @@
     gap: 0.5rem;
 }
 
+/* remove gap from dropdown group */
+.dropdown.btn-group {
+    gap: 0rem;
+}
+
+/* center + icon in the button */
+.array-item-add {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .no-wrap {
     text-wrap: nowrap;
 }

--- a/apps/haddock3-submit/src/App.css
+++ b/apps/haddock3-submit/src/App.css
@@ -1,21 +1,110 @@
+/*
+  Customise workflow builder components
+  NOTE ! copy of apps/haddock3-download/src/App.css
+*/
+
 .page {
     padding: 1em;
     display: grid;
     width: 100%;
     height: 100vh;
     grid-template-areas: "head head head"
-                         "catalog workflow node"
-                         "catalog workflow-actions node-actions";
-    grid-template-columns: 1fr 1fr 2fr;
+        "catalog workflow node"
+        "catalog workflow-actions node-actions";
+    grid-template-columns: min-content minmax(12rem, 1fr) minmax(20rem, 2fr);
     grid-template-rows: auto 1fr auto;
-    column-gap: 0.5rem;
+    column-gap: 1rem;
 }
 
-.page > div {
+/* Style workflow area section */
+.workflow-area{
+    display: flex;
+    flex-direction: column;
+}
+
+/* Style various form buttons */
+.btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.btn-visual-panel,
+.btn-catalog-node {
+    width: 100%;
+}
+
+.btn-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.no-wrap {
+    text-wrap: nowrap;
+}
+
+ul {
+    padding: 0.25rem 0.25rem 0.25rem 1.25rem;
+}
+
+li {
+    list-style-type: none;
+}
+
+li>ul {
+    padding: 0rem;
+}
+
+div[role="button"],
+.btn-catalog-node {
+    margin: 0.5rem 0rem;
+    cursor: pointer;
+}
+
+/* Format actions section at the bottom */
+.action-row,
+.action-row>.nav {
+    display: flex;
+    gap: 1rem;
+    padding: 0.25rem;
+}
+
+.action-row>.nav {
+    flex: 1;
+    justify-content: flex-end;
+}
+
+
+.btn-toolbar {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 0rem;
+}
+
+/* Show panel section is clickable */
+h5[id^="expander4"] {
+    cursor: pointer;
+}
+
+/* Allow scrollbars in the card when content is too large */
+.card-body {
     overflow: auto;
 }
 
-.page > .action-row {
-    padding: 0.25rem;
-    overflow: unset;
+/* Alow scrollbars on tables which exceed card width */
+.form-group>fieldset {
+    overflow: auto;
+}
+
+/* hide commands by default */
+.btn-catalog-node .grip,
+.btn-visual-node .btn-group {
+    visibility: hidden;
+}
+
+/* show commands on hover */
+.btn-catalog-node:hover .grip,
+.btn-visual-node:hover .btn-group {
+    visibility: visible;
 }

--- a/apps/haddock3-submit/src/App.tsx
+++ b/apps/haddock3-submit/src/App.tsx
@@ -26,7 +26,7 @@ function App (): JSX.Element {
             <CatalogPicker />
           </CatalogPanel>
         </GridArea>
-        <GridArea area='workflow'>
+        <GridArea area='workflow' className='workflow-area'>
           <WorkflowPanel />
         </GridArea>
         <GridArea area='node'>

--- a/apps/kitchensink/src/App.css
+++ b/apps/kitchensink/src/App.css
@@ -40,6 +40,18 @@
     gap: 0.5rem;
 }
 
+/* remove gap from dropdown group */
+.dropdown.btn-group {
+    gap: 0rem;
+}
+
+/* center + icon in the button */
+.array-item-add {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
 .no-wrap {
     text-wrap: nowrap;
 }

--- a/apps/kitchensink/src/App.css
+++ b/apps/kitchensink/src/App.css
@@ -1,20 +1,110 @@
+/*
+  Customise workflow builder components
+  NOTE ! copy of apps/haddock3-download/src/App.css
+*/
+
 .page {
     padding: 1em;
     display: grid;
     width: 100%;
     height: 100vh;
     grid-template-areas: "head head head"
-                         "catalog workflow node"
-                         "catalog workflow-actions node-actions";
-    grid-template-columns: 1fr 1fr 2fr;
+        "catalog workflow node"
+        "catalog workflow-actions node-actions";
+    grid-template-columns: min-content minmax(12rem, 1fr) minmax(20rem, 2fr);
     grid-template-rows: auto 1fr auto;
-    column-gap: 0.5rem;
+    column-gap: 1rem;
 }
 
-.page > div {
+/* Style workflow area section */
+.workflow-area {
+    display: flex;
+    flex-direction: column;
+}
+
+/* Style various form buttons */
+.btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.btn-visual-panel,
+.btn-catalog-node {
+    width: 100%;
+}
+
+.btn-group {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.no-wrap {
+    text-wrap: nowrap;
+}
+
+ul {
+    padding: 0.25rem 0.25rem 0.25rem 1.25rem;
+}
+
+li {
+    list-style-type: none;
+}
+
+li>ul {
+    padding: 0rem;
+}
+
+div[role="button"],
+.btn-catalog-node {
+    margin: 0.5rem 0rem;
+    cursor: pointer;
+}
+
+/* Format actions section at the bottom */
+.action-row,
+.action-row>.nav {
+    display: flex;
+    gap: 1rem;
+    padding: 0.25rem;
+}
+
+.action-row>.nav {
+    flex: 1;
+    justify-content: flex-end;
+}
+
+
+.btn-toolbar {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem 0rem;
+}
+
+/* Show panel section is clickable */
+h5[id^="expander4"] {
+    cursor: pointer;
+}
+
+/* Allow scrollbars in the card when content is too large */
+.card-body {
     overflow: auto;
 }
 
-.action-row {
-    padding: 0.25rem
+/* Alow scrollbars on tables which exceed card width */
+.form-group>fieldset {
+    overflow: auto;
+}
+
+/* hide commands by default */
+.btn-catalog-node .grip,
+.btn-visual-node .btn-group {
+    visibility: hidden;
+}
+
+/* show commands on hover */
+.btn-catalog-node:hover .grip,
+.btn-visual-node:hover .btn-group {
+    visibility: visible;
 }

--- a/apps/kitchensink/src/App.tsx
+++ b/apps/kitchensink/src/App.tsx
@@ -32,7 +32,7 @@ function App (): JSX.Element {
       <GridArea area='catalog'>
         <CatalogPanel />
       </GridArea>
-      <GridArea area='workflow'>
+      <GridArea area='workflow' className='workflow-area'>
         <WorkflowPanel>
           <WorkflowUploadButton />
         </WorkflowPanel>

--- a/apps/kitchensink/src/kitchensink.json
+++ b/apps/kitchensink/src/kitchensink.json
@@ -553,7 +553,7 @@
       "category": "resdictests"
     },
     {
-      "id": "node1",
+      "id": "node11",
       "label": "Node with prop1 has same size as global molecules parameter",
       "description": "Description 1",
       "category": "moleculetest",
@@ -582,7 +582,7 @@
       "tomlSchema": {}
     },
     {
-      "id": "node2",
+      "id": "node12",
       "label": "Node same as node1, but with ui:group",
       "description": "Description 1",
       "category": "moleculetest",
@@ -612,7 +612,7 @@
       "tomlSchema": {}
     },
     {
-      "id": "node3",
+      "id": "node13",
       "label": "Node with segments (with chain and residue formats) for each molecule",
       "description": "Description 1",
       "category": "moleculetest",
@@ -672,7 +672,7 @@
       }
     },
     {
-      "id": "node1",
+      "id": "node111",
       "label": "Node with prop1 has same size as global molecules parameter",
       "description": "Description 1",
       "category": "moleculetest",
@@ -701,7 +701,7 @@
       "tomlSchema": {}
     },
     {
-      "id": "node2",
+      "id": "node112",
       "label": "Node same as node1, but with ui:group",
       "description": "Description 1",
       "category": "moleculetest",
@@ -731,7 +731,7 @@
       "tomlSchema": {}
     },
     {
-      "id": "node3",
+      "id": "node113",
       "label": "Node with segments (with chain and residue formats) for each molecule",
       "description": "Description 1",
       "category": "moleculetest",
@@ -791,7 +791,7 @@
       }
     },
     {
-      "id": "node4",
+      "id": "node114",
       "label": "Node with array of object with property which array of scalar. Scalar is a residue and rendered as multi select.",
       "description": "Description 1",
       "category": "moleculetest",
@@ -893,7 +893,7 @@
       }
     },
     {
-        "id": "node12",
+        "id": "node1112",
         "label": "Node in initially collapsed cat",
         "description": "Description 12",
         "category": "collapsedcat",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",
+    "@emotion/react": "^11.9.3",
     "@mdx-js/react": "^1.6.22",
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-docs": "^6.5.9",
@@ -64,7 +65,6 @@
     "@dnd-kit/core": "^6.0.5",
     "@dnd-kit/modifiers": "^6.0.0",
     "@dnd-kit/sortable": "^7.0.1",
-    "@emotion/react": "^11.9.3",
     "@i-vresse/pdbtbx-ts": "0.1.7",
     "@i-vresse/wb-form": "workspace:^",
     "@ltd/j-toml": "^1.24.0",

--- a/packages/core/src/CatalogNode.tsx
+++ b/packages/core/src/CatalogNode.tsx
@@ -1,32 +1,13 @@
-/** @jsxRuntime classic */ // storybook builder can not use default jsxRuntime so overwritting it here.
-/** @jsx jsx */
-import { jsx, css } from '@emotion/react'
+import React from 'react'
 import { useDraggable } from '@dnd-kit/core'
+import {CSS} from '@dnd-kit/utilities'
 
-import { nodeWidth } from './constants'
 import { useWorkflow } from './store'
 import { ICatalogNode } from './types'
 import { GripVertical } from './GripVertical'
 
-const buttonStyle = css({
-  width: `${nodeWidth}rem`,
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  marginBottom: 4,
-
-  '& .grip': {
-    visibility: 'hidden',
-    cursor: 'grab'
-  },
-
-  '&:hover .grip': {
-    visibility: 'visible'
-  }
-})
-
 export const CatalogNode = ({ id, label }: ICatalogNode): JSX.Element => {
-  const { attributes, listeners, setNodeRef, transform, setActivatorNodeRef } =
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform } =
     useDraggable({ id, data: { catalog: true } })
   const dragStyle =
     transform != null
@@ -35,17 +16,21 @@ export const CatalogNode = ({ id, label }: ICatalogNode): JSX.Element => {
         }
       : {}
 
+  const style = {
+    transform: CSS.Translate.toString(transform),
+  };
+
   const { addNodeToWorkflow } = useWorkflow()
 
   return (
     <li>
       <button
         ref={setNodeRef}
-        css={buttonStyle}
-        style={dragStyle}
+        // style={dragStyle}
+        style={style}
         {...attributes}
         title={label}
-        className='btn btn-light btn-sm'
+        className='btn btn-light btn-sm btn-catalog-node'
         onClick={() => addNodeToWorkflow(id)}
       >
         <span>{id}</span>

--- a/packages/core/src/CatalogNode.tsx
+++ b/packages/core/src/CatalogNode.tsx
@@ -7,13 +7,12 @@ import { ICatalogNode } from './types'
 import { GripVertical } from './GripVertical'
 
 export const CatalogNode = ({ id, label }: ICatalogNode): JSX.Element => {
+  const { addNodeToWorkflow } = useWorkflow()
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform } = useDraggable({ id, data: { catalog: true } })
 
   const style = {
     transform: CSS.Translate.toString(transform)
   }
-
-  const { addNodeToWorkflow } = useWorkflow()
 
   return (
     <li>

--- a/packages/core/src/CatalogNode.tsx
+++ b/packages/core/src/CatalogNode.tsx
@@ -1,24 +1,17 @@
 import React from 'react'
 import { useDraggable } from '@dnd-kit/core'
-import {CSS} from '@dnd-kit/utilities'
+import { CSS } from '@dnd-kit/utilities'
 
 import { useWorkflow } from './store'
 import { ICatalogNode } from './types'
 import { GripVertical } from './GripVertical'
 
 export const CatalogNode = ({ id, label }: ICatalogNode): JSX.Element => {
-  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform } =
-    useDraggable({ id, data: { catalog: true } })
-  const dragStyle =
-    transform != null
-      ? {
-          transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`
-        }
-      : {}
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform } = useDraggable({ id, data: { catalog: true } })
 
   const style = {
-    transform: CSS.Translate.toString(transform),
-  };
+    transform: CSS.Translate.toString(transform)
+  }
 
   const { addNodeToWorkflow } = useWorkflow()
 
@@ -26,7 +19,6 @@ export const CatalogNode = ({ id, label }: ICatalogNode): JSX.Element => {
     <li>
       <button
         ref={setNodeRef}
-        // style={dragStyle}
         style={style}
         {...attributes}
         title={label}

--- a/packages/core/src/Example.tsx
+++ b/packages/core/src/Example.tsx
@@ -29,7 +29,7 @@ export const Example = ({ name, workflow }: IProps): JSX.Element => {
   return (
     <li>
       <button
-        className='btn btn-light'
+        className='btn btn-light no-wrap'
         onClick={onClick}
         title={workflow}
       >

--- a/packages/core/src/VisualNode.tsx
+++ b/packages/core/src/VisualNode.tsx
@@ -1,12 +1,10 @@
-/** @jsxRuntime classic */ // storybook builder can not use default jsxRuntime so overwritting it here.
-/** @jsx jsx */
-import { jsx, css } from '@emotion/react'
+import React from 'react'
+
 import { BsX } from 'react-icons/bs'
 import { CSS } from '@dnd-kit/utilities'
 import { useSortable } from '@dnd-kit/sortable'
 
 import { useDraggingWorkflowNodeState, useSelectNodeIndex, useWorkflow } from './store'
-import { nodeWidth } from './constants'
 import { GripVertical } from './GripVertical'
 
 interface IProp {
@@ -14,27 +12,6 @@ interface IProp {
   index: number
   id: string
 }
-
-const buttonStyle = css({
-  width: `${nodeWidth + 2}rem`,
-  display: 'flex',
-  justifyContent: 'space-between',
-  alignItems: 'center',
-  marginBottom: 4,
-  '& .grip': {
-    visibility: 'hidden',
-    cursor: 'grab'
-  },
-  '&:hover .grip': {
-    visibility: 'visible'
-  },
-  '& .delete': {
-    visibility: 'hidden'
-  },
-  '&:hover .delete': {
-    visibility: 'visible'
-  }
-})
 
 export const VisualNode = ({ type, index, id }: IProp): JSX.Element => {
   const selectedNodeIndex = useSelectNodeIndex()
@@ -63,9 +40,8 @@ export const VisualNode = ({ type, index, id }: IProp): JSX.Element => {
   return (
     <div ref={setNodeRef} style={style} {...attributes}>
       <button
-        className='btn btn-light btn-sm btn-block'
+        className='btn btn-light btn-sm btn-block btn-visual-node'
         title='Click to configure'
-        css={buttonStyle}
         style={selectedStyle}
         onClick={() => {
           selectNode(index)

--- a/packages/core/src/VisualPanel.tsx
+++ b/packages/core/src/VisualPanel.tsx
@@ -6,7 +6,6 @@ import {
 } from '@dnd-kit/sortable'
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import { BsX } from 'react-icons/bs'
-import { nodeWidth } from './constants'
 import {
   useDraggingCatalogNodeState,
   useDraggingWorkflowNodeState,
@@ -68,9 +67,8 @@ export const VisualPanel = (): JSX.Element => {
         {draggingCatalogNode !== null
           ? (
             <button
-              style={{ width: `${nodeWidth}rem` }}
               title={`${draggingCatalogNode}`}
-              className='btn btn-light btn-sm'
+              className='btn btn-light btn-sm btn-visual-panel'
             >
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <span>{draggingCatalogNode}</span>
@@ -90,17 +88,16 @@ export const VisualPanel = (): JSX.Element => {
         {draggingWorkflowNode !== undefined
           ? (
             <button
-              style={{ width: `${nodeWidth + 2}rem` }}
-              className='btn btn-light btn-sm'
+              className='btn btn-light btn-sm btn-visual-panel'
             >
               <div style={{ display: 'flex', justifyContent: 'space-between' }}>
                 <span>{draggingWorkflowNode.type}</span>
                 <div className='btn-group'>
                   <div className='btn btn-light btn-sm'>
-                    <GripVertical />
+                    <BsX />
                   </div>
                   <div className='btn btn-light btn-sm'>
-                    <BsX />
+                    <GripVertical />
                   </div>
                 </div>
               </div>

--- a/packages/core/src/VisualPanel.tsx
+++ b/packages/core/src/VisualPanel.tsx
@@ -23,7 +23,7 @@ export const VisualPanel = (): JSX.Element => {
   )
 
   const appendZoneStyle: CSSProperties = {
-    padding: 10,
+    padding: '1rem',
     textAlign: 'center'
   }
   const appendZone = (
@@ -56,7 +56,13 @@ export const VisualPanel = (): JSX.Element => {
   }
   const { setNodeRef } = useDroppable({ id: 'catalog-dropzone' })
   return (
-    <div ref={setNodeRef} style={{ height: '100%' }}>
+    <div
+      ref={setNodeRef} style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column'
+      }}
+    >
       <SortableContext
         items={sortableItems}
         strategy={verticalListSortingStrategy}
@@ -65,44 +71,36 @@ export const VisualPanel = (): JSX.Element => {
       </SortableContext>
       <DragOverlay dropAnimation={null}>
         {draggingCatalogNode !== null
-          ? (
-            <button
+          ? <button
               title={`${draggingCatalogNode}`}
               className='btn btn-light btn-sm btn-visual-panel'
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <span>{draggingCatalogNode}</span>
-                <div
-                  className='btn btn-light btn-sm'
-                  title='Move'
-                  style={{ cursor: 'grab' }}
-                >
-                  <GripVertical />
-                </div>
-              </div>
+            <span>{draggingCatalogNode}</span>
+            <div
+              className='btn btn-light btn-sm'
+              title='Move'
+              style={{ cursor: 'grab' }}
+            >
+              <GripVertical />
+            </div>
             </button>
-            )
           : null}
       </DragOverlay>
       <DragOverlay modifiers={[restrictToVerticalAxis]}>
         {draggingWorkflowNode !== undefined
-          ? (
-            <button
+          ? <button
               className='btn btn-light btn-sm btn-visual-panel'
             >
-              <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <span>{draggingWorkflowNode.type}</span>
-                <div className='btn-group'>
-                  <div className='btn btn-light btn-sm'>
-                    <BsX />
-                  </div>
-                  <div className='btn btn-light btn-sm'>
-                    <GripVertical />
-                  </div>
-                </div>
+            <span>{draggingWorkflowNode.type}</span>
+            <div className='btn-group'>
+              <div className='btn btn-light btn-sm'>
+                <GripVertical />
               </div>
+              <div className='btn btn-light btn-sm'>
+                <BsX />
+              </div>
+            </div>
             </button>
-            )
           : null}
       </DragOverlay>
     </div>

--- a/packages/core/src/VisualPanel.tsx
+++ b/packages/core/src/VisualPanel.tsx
@@ -71,36 +71,40 @@ export const VisualPanel = (): JSX.Element => {
       </SortableContext>
       <DragOverlay dropAnimation={null}>
         {draggingCatalogNode !== null
-          ? <button
+          ? (
+            <button
               title={`${draggingCatalogNode}`}
               className='btn btn-light btn-sm btn-visual-panel'
             >
-            <span>{draggingCatalogNode}</span>
-            <div
-              className='btn btn-light btn-sm'
-              title='Move'
-              style={{ cursor: 'grab' }}
-            >
-              <GripVertical />
-            </div>
+              <span>{draggingCatalogNode}</span>
+              <div
+                className='btn btn-light btn-sm'
+                title='Move'
+                style={{ cursor: 'grab' }}
+              >
+                <GripVertical />
+              </div>
             </button>
+            )
           : null}
       </DragOverlay>
       <DragOverlay modifiers={[restrictToVerticalAxis]}>
         {draggingWorkflowNode !== undefined
-          ? <button
+          ? (
+            <button
               className='btn btn-light btn-sm btn-visual-panel'
             >
-            <span>{draggingWorkflowNode.type}</span>
-            <div className='btn-group'>
-              <div className='btn btn-light btn-sm'>
-                <GripVertical />
+              <span>{draggingWorkflowNode.type}</span>
+              <div className='btn-group'>
+                <div className='btn btn-light btn-sm'>
+                  <GripVertical />
+                </div>
+                <div className='btn btn-light btn-sm'>
+                  <BsX />
+                </div>
               </div>
-              <div className='btn btn-light btn-sm'>
-                <BsX />
-              </div>
-            </div>
             </button>
+            )
           : null}
       </DragOverlay>
     </div>

--- a/packages/core/src/WorkflowPanel.tsx
+++ b/packages/core/src/WorkflowPanel.tsx
@@ -19,23 +19,26 @@ export const WorkflowPanel = ({ children }: PropsWithChildren<{}>): JSX.Element 
   const textTabStyle = tab === 'text' ? 'nav-link active' : 'nav-link'
 
   return (
-    <fieldset>
+    <fieldset style={{
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column'
+    }}
+    >
       <legend>Workflow</legend>
-      <div style={{ display: 'flex', flexFlow: 'column', height: '100%', gap: '5px', paddingBottom: '5px' }}>
-        <div className='btn-toolbar'>
-          <button className='btn btn-light' onClick={toggleGlobalEdit} title='Edit global parameters'>Global parameters</button>
-          {children}
-        </div>
-        <ul className='nav nav-tabs'>
-          <li className='nav-item'>
-            <button className={visualTabStyle} onClick={() => setTab('visual')}>Visual</button>
-          </li>
-          <li className='nav-item'>
-            <button className={textTabStyle} onClick={() => setTab('text')}>Text</button>
-          </li>
-        </ul>
-        {selectedPanel}
+      <div className='btn-toolbar'>
+        <button className='btn btn-light' onClick={toggleGlobalEdit} title='Edit global parameters'>Global parameters</button>
+        {children}
       </div>
+      <ul className='nav nav-tabs'>
+        <li className='nav-item'>
+          <button className={visualTabStyle} onClick={() => setTab('visual')}>Visual</button>
+        </li>
+        <li className='nav-item'>
+          <button className={textTabStyle} onClick={() => setTab('text')}>Text</button>
+        </li>
+      </ul>
+      {selectedPanel}
     </fieldset>
   )
 }

--- a/packages/core/src/WorkflowPanel.tsx
+++ b/packages/core/src/WorkflowPanel.tsx
@@ -19,7 +19,7 @@ export const WorkflowPanel = ({ children }: PropsWithChildren<{}>): JSX.Element 
   const textTabStyle = tab === 'text' ? 'nav-link active' : 'nav-link'
 
   return (
-    <fieldset style={{ height: '100%' }}>
+    <fieldset>
       <legend>Workflow</legend>
       <div style={{ display: 'flex', flexFlow: 'column', height: '100%', gap: '5px', paddingBottom: '5px' }}>
         <div className='btn-toolbar'>

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -8,4 +8,3 @@ export const workflowFilename = 'workflow.cfg'
  */
 export const workflowArchiveFilename = 'workflow.zip'
 
-export const nodeWidth = 10

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -7,4 +7,3 @@ export const workflowFilename = 'workflow.cfg'
  * File name to store workflow archive as
  */
 export const workflowArchiveFilename = 'workflow.zip'
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,6 +249,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.16.7":
+  version: 7.22.15
+  resolution: "@babel/helper-module-imports@npm:7.22.15"
+  dependencies:
+    "@babel/types": ^7.22.15
+  checksum: ecd7e457df0a46f889228f943ef9b4a47d485d82e030676767e6a2fdcbdaa63594d8124d4b55fd160b41c201025aec01fc27580352b1c87a37c9c6f33d116702
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.12.1, @babel/helper-module-transforms@npm:^7.18.6":
   version: 7.18.8
   resolution: "@babel/helper-module-transforms@npm:7.18.8"
@@ -342,10 +351,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.23.4":
+  version: 7.23.4
+  resolution: "@babel/helper-string-parser@npm:7.23.4"
+  checksum: c0641144cf1a7e7dc93f3d5f16d5327465b6cf5d036b48be61ecba41e1eece161b48f46b7f960951b67f8c3533ce506b16dece576baef4d8b3b49f8c65410f90
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/helper-validator-identifier@npm:7.18.6"
   checksum: e295254d616bbe26e48c196a198476ab4d42a73b90478c9842536cf910ead887f5af6b5c4df544d3052a25ccb3614866fa808dc1e3a5a4291acd444e243c0648
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
+  checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
   languageName: node
   linkType: hard
 
@@ -773,7 +796,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.12.13, @babel/plugin-syntax-jsx@npm:^7.18.6":
+"@babel/plugin-syntax-jsx@npm:^7.18.6":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
   dependencies:
@@ -1525,12 +1548,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.8, @babel/runtime@npm:^7.14.0, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.3, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.18.6
   resolution: "@babel/runtime@npm:7.18.6"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: 8b707b64ae0524db617d0c49933b258b96376a38307dc0be8fb42db5697608bcc1eba459acce541e376cff5ed5c5287d24db5780bd776b7c75ba2c2e26ff8a2c
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.18.3":
+  version: 7.24.0
+  resolution: "@babel/runtime@npm:7.24.0"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 7a6a5d40fbdd68491ec183ba2e631c07415119960083b4fd76564cce3751e9acd2f12ab89575e38496fa389fa06d458732776e69ee1858e366cc3fbdb049f847
   languageName: node
   linkType: hard
 
@@ -1579,6 +1611,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.18.6
     to-fast-properties: ^2.0.0
   checksum: a485531faa9ff3b83ea94ba6502321dd66e39202c46d7765e4336cb4aff2ff69ebc77d97b17e21331a8eedde1f5490ce00e8a430c1041fc26854d636e6701919
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.22.15":
+  version: 7.24.0
+  resolution: "@babel/types@npm:7.24.0"
+  dependencies:
+    "@babel/helper-string-parser": ^7.23.4
+    "@babel/helper-validator-identifier": ^7.22.20
+    to-fast-properties: ^2.0.0
+  checksum: 4b574a37d490f621470ff36a5afaac6deca5546edcb9b5e316d39acbb20998e9c2be42f3fc0bf2b55906fc49ff2a5a6a097e8f5a726ee3f708a0b0ca93aed807
   languageName: node
   linkType: hard
 
@@ -1749,116 +1792,120 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/babel-plugin@npm:^11.7.1":
-  version: 11.9.2
-  resolution: "@emotion/babel-plugin@npm:11.9.2"
+"@emotion/babel-plugin@npm:^11.11.0":
+  version: 11.11.0
+  resolution: "@emotion/babel-plugin@npm:11.11.0"
   dependencies:
-    "@babel/helper-module-imports": ^7.12.13
-    "@babel/plugin-syntax-jsx": ^7.12.13
-    "@babel/runtime": ^7.13.10
-    "@emotion/hash": ^0.8.0
-    "@emotion/memoize": ^0.7.5
-    "@emotion/serialize": ^1.0.2
-    babel-plugin-macros: ^2.6.1
+    "@babel/helper-module-imports": ^7.16.7
+    "@babel/runtime": ^7.18.3
+    "@emotion/hash": ^0.9.1
+    "@emotion/memoize": ^0.8.1
+    "@emotion/serialize": ^1.1.2
+    babel-plugin-macros: ^3.1.0
     convert-source-map: ^1.5.0
     escape-string-regexp: ^4.0.0
     find-root: ^1.1.0
     source-map: ^0.5.7
-    stylis: 4.0.13
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: 2d2c4fadd389862896bcbc5f42c9b9c1a199810173fcf14e5520506c7179c2ddb991b8832fd273f42104cf0dae98886ad8e767b5e38ad235b652d903c3b8a328
+    stylis: 4.2.0
+  checksum: 6b363edccc10290f7a23242c06f88e451b5feb2ab94152b18bb8883033db5934fb0e421e2d67d09907c13837c21218a3ac28c51707778a54d6cd3706c0c2f3f9
   languageName: node
   linkType: hard
 
-"@emotion/cache@npm:^11.9.3":
-  version: 11.9.3
-  resolution: "@emotion/cache@npm:11.9.3"
+"@emotion/cache@npm:^11.11.0":
+  version: 11.11.0
+  resolution: "@emotion/cache@npm:11.11.0"
   dependencies:
-    "@emotion/memoize": ^0.7.4
-    "@emotion/sheet": ^1.1.1
-    "@emotion/utils": ^1.0.0
-    "@emotion/weak-memoize": ^0.2.5
-    stylis: 4.0.13
-  checksum: 6e0aab2fa5b9b6b0b9bf66b5328ed44265c23ced16b46c13d2602c3497fabd95299f6cf2c87cbc02b630452aa3cff599c194c538125d744aa135824129698ccc
+    "@emotion/memoize": ^0.8.1
+    "@emotion/sheet": ^1.2.2
+    "@emotion/utils": ^1.2.1
+    "@emotion/weak-memoize": ^0.3.1
+    stylis: 4.2.0
+  checksum: 8eb1dc22beaa20c21a2e04c284d5a2630a018a9d51fb190e52de348c8d27f4e8ca4bbab003d68b4f6cd9cc1c569ca747a997797e0f76d6c734a660dc29decf08
   languageName: node
   linkType: hard
 
-"@emotion/hash@npm:^0.8.0":
-  version: 0.8.0
-  resolution: "@emotion/hash@npm:0.8.0"
-  checksum: 4b35d88a97e67275c1d990c96d3b0450451d089d1508619488fc0acb882cb1ac91e93246d471346ebd1b5402215941ef4162efe5b51534859b39d8b3a0e3ffaa
+"@emotion/hash@npm:^0.9.1":
+  version: 0.9.1
+  resolution: "@emotion/hash@npm:0.9.1"
+  checksum: 716e17e48bf9047bf9383982c071de49f2615310fb4e986738931776f5a823bc1f29c84501abe0d3df91a3803c80122d24e28b57351bca9e01356ebb33d89876
   languageName: node
   linkType: hard
 
-"@emotion/memoize@npm:^0.7.4, @emotion/memoize@npm:^0.7.5":
-  version: 0.7.5
-  resolution: "@emotion/memoize@npm:0.7.5"
-  checksum: 83da8d4a7649a92c72f960817692bc6be13cc13e107b9f7e878d63766525ed4402881bfeb3cda61145c050281e7e260f114a0a2870515527346f2ef896b915b3
+"@emotion/memoize@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@emotion/memoize@npm:0.8.1"
+  checksum: a19cc01a29fcc97514948eaab4dc34d8272e934466ed87c07f157887406bc318000c69ae6f813a9001c6a225364df04249842a50e692ef7a9873335fbcc141b0
   languageName: node
   linkType: hard
 
 "@emotion/react@npm:^11.9.3":
-  version: 11.9.3
-  resolution: "@emotion/react@npm:11.9.3"
+  version: 11.11.4
+  resolution: "@emotion/react@npm:11.11.4"
   dependencies:
-    "@babel/runtime": ^7.13.10
-    "@emotion/babel-plugin": ^11.7.1
-    "@emotion/cache": ^11.9.3
-    "@emotion/serialize": ^1.0.4
-    "@emotion/utils": ^1.1.0
-    "@emotion/weak-memoize": ^0.2.5
+    "@babel/runtime": ^7.18.3
+    "@emotion/babel-plugin": ^11.11.0
+    "@emotion/cache": ^11.11.0
+    "@emotion/serialize": ^1.1.3
+    "@emotion/use-insertion-effect-with-fallbacks": ^1.0.1
+    "@emotion/utils": ^1.2.1
+    "@emotion/weak-memoize": ^0.3.1
     hoist-non-react-statics: ^3.3.1
   peerDependencies:
-    "@babel/core": ^7.0.0
     react: ">=16.8.0"
   peerDependenciesMeta:
-    "@babel/core":
-      optional: true
     "@types/react":
       optional: true
-  checksum: 19bc7205e85e87cadebbe5a926d45103b836af70ab6972ea4c333c8dd01b463fc9646d4e4097a36f145a05dd4bc388739667437b990f8cf7f7f925f9610d1aa8
+  checksum: 6abaa7a05c5e1db31bffca7ac79169f5456990022cbb3794e6903221536609a60420f2b4888dd3f84e9634a304e394130cb88dc32c243a1dedc263e50da329f8
   languageName: node
   linkType: hard
 
-"@emotion/serialize@npm:^1.0.2, @emotion/serialize@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "@emotion/serialize@npm:1.0.4"
+"@emotion/serialize@npm:^1.1.2, @emotion/serialize@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@emotion/serialize@npm:1.1.3"
   dependencies:
-    "@emotion/hash": ^0.8.0
-    "@emotion/memoize": ^0.7.4
-    "@emotion/unitless": ^0.7.5
-    "@emotion/utils": ^1.0.0
+    "@emotion/hash": ^0.9.1
+    "@emotion/memoize": ^0.8.1
+    "@emotion/unitless": ^0.8.1
+    "@emotion/utils": ^1.2.1
     csstype: ^3.0.2
-  checksum: e8cc342056734e176ea837fe44035126dea174962db40852a7ced499d258c0056b0fd3c298743c446f9ba0f2647cb42dfb623b8e5783c265deb9eb20138d68e7
+  checksum: 5a756ce7e2692322683978d8ed2e84eadd60bd6f629618a82c5018c84d98684b117e57fad0174f68ec2ec0ac089bb2e0bcc8ea8c2798eb904b6d3236aa046063
   languageName: node
   linkType: hard
 
-"@emotion/sheet@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@emotion/sheet@npm:1.1.1"
-  checksum: b916ac665735ef6dfda26b09f2d3493789d432d649733db9da18c4db0115e7fdadeb8d45f6490320248916bb13d978bba74c914b711ac96f659b76a5e52d5cd2
+"@emotion/sheet@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "@emotion/sheet@npm:1.2.2"
+  checksum: d973273c9c15f1c291ca2269728bf044bd3e92a67bca87943fa9ec6c3cd2b034f9a6bfe95ef1b5d983351d128c75b547b43ff196a00a3875f7e1d269793cecfe
   languageName: node
   linkType: hard
 
-"@emotion/unitless@npm:^0.7.5":
-  version: 0.7.5
-  resolution: "@emotion/unitless@npm:0.7.5"
-  checksum: f976e5345b53fae9414a7b2e7a949aa6b52f8bdbcc84458b1ddc0729e77ba1d1dfdff9960e0da60183877873d3a631fa24d9695dd714ed94bcd3ba5196586a6b
+"@emotion/unitless@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@emotion/unitless@npm:0.8.1"
+  checksum: 385e21d184d27853bb350999471f00e1429fa4e83182f46cd2c164985999d9b46d558dc8b9cc89975cb337831ce50c31ac2f33b15502e85c299892e67e7b4a88
   languageName: node
   linkType: hard
 
-"@emotion/utils@npm:^1.0.0, @emotion/utils@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@emotion/utils@npm:1.1.0"
-  checksum: d3b681ca3a23b07033ac6c6937e71010a5549ac8ccec325eb6c91a7e48d9a73db83fa5dadc58be981bb125d7c00fedca868ea4362b1da9e02866615f96be4df1
+"@emotion/use-insertion-effect-with-fallbacks@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@emotion/use-insertion-effect-with-fallbacks@npm:1.0.1"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 700b6e5bbb37a9231f203bb3af11295eed01d73b2293abece0bc2a2237015e944d7b5114d4887ad9a79776504aa51ed2a8b0ddbc117c54495dd01a6b22f93786
   languageName: node
   linkType: hard
 
-"@emotion/weak-memoize@npm:^0.2.5":
-  version: 0.2.5
-  resolution: "@emotion/weak-memoize@npm:0.2.5"
-  checksum: 27d402b0c683b94658220b6d47840346ee582329ca2a15ec9c233492e0f1a27687ccb233b76eedc922f2e185e444cc89f7b97a81a1d3e5ae9f075bab08e965ea
+"@emotion/utils@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@emotion/utils@npm:1.2.1"
+  checksum: e0b44be0705b56b079c55faff93952150be69e79b660ae70ddd5b6e09fc40eb1319654315a9f34bb479d7f4ec94be6068c061abbb9e18b9778ae180ad5d97c73
+  languageName: node
+  linkType: hard
+
+"@emotion/weak-memoize@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@emotion/weak-memoize@npm:0.3.1"
+  checksum: b2be47caa24a8122622ea18cd2d650dbb4f8ad37b636dc41ed420c2e082f7f1e564ecdea68122b546df7f305b159bf5ab9ffee872abd0f052e687428459af594
   languageName: node
   linkType: hard
 
@@ -5402,18 +5449,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-macros@npm:^2.6.1":
-  version: 2.8.0
-  resolution: "babel-plugin-macros@npm:2.8.0"
-  dependencies:
-    "@babel/runtime": ^7.7.2
-    cosmiconfig: ^6.0.0
-    resolve: ^1.12.0
-  checksum: 59b09a21cf3ae1e14186c1b021917d004b49b953824b24953a54c6502da79e8051d4ac31cfd4a0ae7f6ea5ddf1f7edd93df4895dd3c3982a5b2431859c2889ac
-  languageName: node
-  linkType: hard
-
-"babel-plugin-macros@npm:^3.0.1":
+"babel-plugin-macros@npm:^3.0.1, babel-plugin-macros@npm:^3.1.0":
   version: 3.1.0
   resolution: "babel-plugin-macros@npm:3.1.0"
   dependencies:
@@ -6548,12 +6584,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.5.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
+"convert-source-map@npm:^1.4.0, convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
   version: 1.8.0
   resolution: "convert-source-map@npm:1.8.0"
   dependencies:
     safe-buffer: ~5.1.1
   checksum: 985d974a2d33e1a2543ada51c93e1ba2f73eaed608dc39f229afc78f71dcc4c8b7d7c684aa647e3c6a3a204027444d69e53e169ce94e8d1fa8d7dee80c9c8fed
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^1.5.0":
+  version: 1.9.0
+  resolution: "convert-source-map@npm:1.9.0"
+  checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
   languageName: node
   linkType: hard
 
@@ -13779,6 +13822,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 9f57c93277b5585d3c83b0cf76be47b473ae8c6d9142a46ce8b0291a04bb2cf902059f0f8445dcabb3fb7378e5fe4bb4ea1e008876343d42e46d3b484534ce38
+  languageName: node
+  linkType: hard
+
 "regenerator-transform@npm:^0.15.0":
   version: 0.15.0
   resolution: "regenerator-transform@npm:0.15.0"
@@ -14020,7 +14070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.12.0, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1, resolve@npm:^1.3.2":
+"resolve@npm:^1.10.0, resolve@npm:^1.10.1, resolve@npm:^1.14.2, resolve@npm:^1.17.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.0, resolve@npm:^1.22.1, resolve@npm:^1.3.2":
   version: 1.22.1
   resolution: "resolve@npm:1.22.1"
   dependencies:
@@ -14046,7 +14096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.12.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.10.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.14.2#~builtin<compat/resolve>, resolve@patch:resolve@^1.17.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.19.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>, resolve@patch:resolve@^1.3.2#~builtin<compat/resolve>":
   version: 1.22.1
   resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
   dependencies:
@@ -15059,10 +15109,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:4.0.13":
-  version: 4.0.13
-  resolution: "stylis@npm:4.0.13"
-  checksum: 8ea7a87028b6383c6a982231c4b5b6150031ce028e0fdaf7b2ace82253d28a8af50cc5a9da8a421d3c7c4441592f393086e332795add672aa4a825f0fe3713a3
+"stylis@npm:4.2.0":
+  version: 4.2.0
+  resolution: "stylis@npm:4.2.0"
+  checksum: 0eb6cc1b866dc17a6037d0a82ac7fa877eba6a757443e79e7c4f35bacedbf6421fadcab4363b39667b43355cbaaa570a3cde850f776498e5450f32ed2f9b7584
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Based on the feedback from users of haddock web app and the investigation performed in [this issue](https://github.com/i-VRESSE/haddock3-webapp/issues/78) it is been decided to remove css-in-js styles from core library. Instead, the specific classes are added which can be used for customization `btn-catalog-node`, `btn-visual-node`, `btn-visual-panel`. 

It was not possible to completely remove @emotion dependency. There were build errors with the storybook components.  I moved @emotion to devDependencies for now.

After removing  styles from core lib, the (example) download app styles are extended. Additional (similar) work might be needed in the other apps (I have not checked it actually).

## Example download app (with changed styles)

![image](https://github.com/i-VRESSE/workflow-builder/assets/9204081/787c0ad7-91b8-4fe1-8707-81e5d54c161c)
