### PR TITLE
Allow required property with default value to be absent

### DIFF
--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -61,6 +61,23 @@ describe('validateWorkflow()', () => {
       ]
       expect(errors).toEqual(expected)
     })
+
+    describe('with default value', () => {
+      it('should be valid if missing', async () => {
+        if (schemas.global.schema.properties !== undefined && typeof schemas.global.schema.properties.run_dir === 'object') {
+          schemas.global.schema.properties.run_dir.default = 'run1'
+        }
+        console.log(JSON.stringify(schemas.global.schema, null, 2))
+        const workflow = {
+          global: {
+          },
+          nodes: []
+        }
+        const errors = await validateWorkflow(workflow, schemas)
+
+        expect(errors).toEqual([])
+      })
+    })
   })
 
   describe('given schema of node', () => {

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -64,10 +64,24 @@ describe('validateWorkflow()', () => {
 
     describe('with default value', () => {
       it('should be valid if missing', async () => {
-        if (schemas.global.schema.properties !== undefined && typeof schemas.global.schema.properties.run_dir === 'object') {
-          schemas.global.schema.properties.run_dir.default = 'run1'
+        const globalSchema: JSONSchema7 = {
+          type: 'object',
+          properties: {
+            run_dir: {
+              type: 'string',
+              default: 'run1'
+            }
+          },
+          required: ['run_dir'],
+          additionalProperties: false
         }
-        console.log(JSON.stringify(schemas.global.schema, null, 2))
+        const schemas = {
+          global: {
+            schema: globalSchema,
+            uiSchema: {}
+          },
+          nodes: []
+        }
         const workflow = {
           global: {
           },

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -21,6 +21,7 @@ const ajv = new Ajv({
   // To silence `strict mode: "items" is 1-tuple, but minItems or maxItems/additionalItems are not specified or different at path` message
   // the strictTuples check can be disable by uncommenting next line
   // strictTuples: false
+  useDefaults: true
 })
 addFormats(ajv)
 addMoleculeFormats(ajv)


### PR DESCRIPTION
Refs #154

Can be tested with

1. Add `default: output` to `packages/haddock3_catalog/public/catalog/haddock3.easy.yaml:global.schema.properties.run_dir`
2. `yarn dev`
3. open haddock3-download application on http://localhost:3000
4. Upload a workflow.cfg without run_dir key.
5. It should be loaded and valid.
