### PR TITLE
When a value for a then|else prop is given then additionalProperties …

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -151,6 +151,7 @@ For example to have the `foo` property only if the `bar` property is false use:
 
 ```yaml
     type: object
+    additionalProperties: true
     properties:
       bar:
         type: boolean
@@ -166,3 +167,4 @@ For example to have the `foo` property only if the `bar` property is false use:
 ```
 
 Only supports simple const condition with one or more properties and not complex conditions like patterns. Also only a single if/tnen/else block per object is supported. It can be combined with [groups](uiSchema.md#uigroup).
+Also only supported with `additionalProperties: true` present in the schema.

--- a/packages/core/src/validate.test.ts
+++ b/packages/core/src/validate.test.ts
@@ -399,6 +399,121 @@ describe('validateWorkflow()', () => {
       })
     })
   })
+
+  describe('given gloal schema with ifthenelse block', () => {
+    it('should be valid when then parameter is given', async () => {
+      const schemas: IWorkflowSchema = {
+        global: {
+          schema: {
+            type: 'object',
+            properties: {
+              ifpar: {
+                type: 'boolean',
+                default: false
+              }
+            },
+            if: {
+              properties: {
+                ifpar: {
+                  const: true
+                }
+              }
+            },
+            then: {
+              properties: {
+                thenpar: {
+                  type: 'number'
+                }
+              }
+            },
+            else: {
+              properties: {
+                elsepar: {
+                  type: 'number'
+                }
+              }
+            },
+            additionalProperties: true
+          },
+          uiSchema: {
+
+          }
+        },
+        nodes: []
+      }
+      const workflow = {
+        global: {
+          ifpar: true,
+          thenpar: 1234
+        },
+        nodes: []
+      }
+      const errors = await validateWorkflow(workflow, schemas)
+      expect(errors).toEqual([])
+    })
+
+    it('should be invalid when invalid then parameter is given', async () => {
+      const schemas: IWorkflowSchema = {
+        global: {
+          schema: {
+            type: 'object',
+            properties: {
+              ifpar: {
+                type: 'boolean',
+                default: false
+              }
+            },
+            if: {
+              properties: {
+                ifpar: {
+                  const: true
+                }
+              }
+            },
+            then: {
+              properties: {
+                thenpar: {
+                  type: 'number',
+                  minimum: 0
+                }
+              }
+            },
+            else: {
+              properties: {
+                elsepar: {
+                  type: 'number'
+                }
+              }
+            },
+            additionalProperties: true
+          },
+          uiSchema: {
+
+          }
+        },
+        nodes: []
+      }
+      const workflow = {
+        global: {
+          ifpar: true,
+          thenpar: -1234
+        },
+        nodes: []
+      }
+      const errors = await validateWorkflow(workflow, schemas)
+      expect(errors).toEqual([{
+        instancePath: '/thenpar',
+        keyword: 'minimum',
+        message: 'must be >= 0',
+        params: {
+          comparison: '>=',
+          limit: 0
+        },
+        schemaPath: '#/then/properties/thenpar/minimum',
+        workflowPath: 'global'
+      }])
+    })
+  })
 })
 
 describe('validateCatalog()', () => {

--- a/packages/haddock3_catalog/generate_haddock3_catalog.py
+++ b/packages/haddock3_catalog/generate_haddock3_catalog.py
@@ -366,7 +366,9 @@ def config2schema(config):
         "type": "object",
         "properties": properties,
         "required": required,
-        "additionalProperties": False
+        // Ajv only allows props from then|else block if additionalProperties is true
+        // otherwise ajv will give "must NOT have additional properties" error
+        "additionalProperties": bool(ifthenelses)
     }
     if ifthenelses:
         if len(ifthenelses) > 1:

--- a/packages/haddock3_catalog/public/catalog/haddock3.easy.yaml
+++ b/packages/haddock3_catalog/public/catalog/haddock3.easy.yaml
@@ -165,7 +165,7 @@ global:
         type: boolean
     required:
     - run_dir
-    additionalProperties: false
+    additionalProperties: true
     if:
       properties:
         mode:

--- a/packages/haddock3_catalog/public/catalog/haddock3.expert.yaml
+++ b/packages/haddock3_catalog/public/catalog/haddock3.expert.yaml
@@ -175,7 +175,7 @@ global:
         type: boolean
     required:
     - run_dir
-    additionalProperties: false
+    additionalProperties: true
     if:
       properties:
         mode:

--- a/packages/haddock3_catalog/public/catalog/haddock3.guru.yaml
+++ b/packages/haddock3_catalog/public/catalog/haddock3.guru.yaml
@@ -185,7 +185,7 @@ global:
         type: boolean
     required:
     - run_dir
-    additionalProperties: false
+    additionalProperties: true
     if:
       properties:
         mode:


### PR DESCRIPTION
…must be true

Fixes #164


By setting "additionalProperties: true", you can have extra global parameters using the haddock3 catalogs so giving less_io parameter is ok, but also any other is ok. As less_io is validated against schema and other additional props are always valid.