### PR TITLE
Skip his* parameters from topoaa.mol1 on easy level

### DIFF
--- a/packages/haddock3_catalog/generate_haddock3_catalog.py
+++ b/packages/haddock3_catalog/generate_haddock3_catalog.py
@@ -408,7 +408,21 @@ def filter_on_level(config, level):
         valid_levels.add(l)
         if l == level:
             break
-    return {k: v for k, v in config.items() if v['explevel'] in valid_levels and not v['explevel'] == _hidden_level}
+    filtered_config = {}
+    for k, v in config.items():
+        if v['explevel'] in valid_levels and v['explevel'] != _hidden_level:
+            filtered_v = v
+            # topoaa.mol1 has some parameters that are easy and some that are expert
+            # need to filter out the expert ones when level=easy
+            if 'type' in v and v['type'] == 'dict':
+                filtered_v = {}
+                for k2, v2 in v.items():
+                    if 'explevel' not in v2:
+                        filtered_v[k2] = v2
+                    if 'explevel' in v2 and v2['explevel'] in valid_levels and v2['explevel'] != _hidden_level:
+                        filtered_v[k2] = v2
+            filtered_config[k] = filtered_v
+    return filtered_config
 
 def process_module(module_name, category, level):
     logging.warning(f'Processing module: {module_name}')

--- a/packages/haddock3_catalog/public/catalog/haddock3.easy.yaml
+++ b/packages/haddock3_catalog/public/catalog/haddock3.easy.yaml
@@ -1877,52 +1877,6 @@ nodes:
                 are within 2A. This cutoff can be changed in the generate-topology.cns
                 script.
               type: boolean
-            nhisd:
-              default: 0
-              title: Number of HISD residue
-              description: Defines the number of HISD residues (neutral HIS with the
-                proton on the ND atom) residues when autohis=false
-              $comment: Defines the number of HISD residues (neutral HIS with the
-                proton on the ND atom) residues. The corresponding residue numbers
-                must be defined in the following parameter (hisd_1, hisd_2, ...).
-                Add as many as needed. Note that HIS is interpreted as a charged Histidine)
-              type: number
-              maximum: 9999
-              minimum: 0
-            hisd:
-              type: array
-              title: Histidines to be defined as HISD
-              items:
-                title: HISD residue number
-                description: Residue number of the Histidine to be defined as HISD
-                $comment: Residue number of the Histidine to be defined as HISD
-                type: number
-                maximum: 9999
-                minimum: -9999
-                format: residue
-            nhise:
-              default: 0
-              title: Number of HISE residue
-              description: Defines the number of HISE residues (neutral HIS with the
-                proton on the NE atom) residues when autohis=false
-              $comment: Defines the number of HISE residues (neutral HIS with the
-                proton on the NE atom) residues. The corresponding residue numbers
-                must be defined in the following parameter (hise_1, hise_2, ...).
-                Add as many as needed. Note that HIS is interpreted as a charged Histidine)
-              type: number
-              maximum: 9999
-              minimum: 0
-            hise:
-              type: array
-              title: Histidines to be defined as HISE
-              items:
-                title: HISE residue number
-                description: Residue number of the Histidine to be defined as HISE
-                $comment: Residue number of the Histidine to be defined as HISE
-                type: number
-                maximum: 9999
-                minimum: -9999
-                format: residue
           required: []
           additionalProperties: false
         maxItemsFrom: molecules
@@ -1945,10 +1899,5 @@ nodes:
       indexed: true
       items:
         sectioned: true
-        properties:
-          hisd:
-            indexed: true
-          hise:
-            indexed: true
 examples:
   docking-protein-ligand: /examples/docking-protein-ligand.zip


### PR DESCRIPTION
Fixes https://github.com/haddocking/haddock3/issues/835